### PR TITLE
Fix race condition on ScrutinyClient connect

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -27,6 +27,6 @@ fi
 set -x 
 export QT_QPA_PLATFORM=offscreen
 python3 -m mypy scrutiny  # .mypy.ini dictacte the rules
-python3 -m coverage run --data-file ${COV_DATAFILE} -m scrutiny runtest
+python3 -m coverage run --data-file ${COV_DATAFILE} -m scrutiny runtest sdk.test_client --loglevel debug
 python3 -m coverage report --data-file ${COV_DATAFILE}
 python3 -m coverage html --data-file ${COV_DATAFILE} -d $HTML_COVDIR

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -27,6 +27,6 @@ fi
 set -x 
 export QT_QPA_PLATFORM=offscreen
 python3 -m mypy scrutiny  # .mypy.ini dictacte the rules
-python3 -m coverage run --data-file ${COV_DATAFILE} -m scrutiny runtest sdk.test_client --loglevel debug
+python3 -m coverage run --data-file ${COV_DATAFILE} -m scrutiny runtest
 python3 -m coverage report --data-file ${COV_DATAFILE}
 python3 -m coverage html --data-file ${COV_DATAFILE} -d $HTML_COVDIR

--- a/scrutiny/sdk/client.py
+++ b/scrutiny/sdk/client.py
@@ -1562,6 +1562,7 @@ class ScrutinyClient:
         """
         timeout = validation.assert_float_range(timeout, 'timeout', minval=0)
         self._threading_events.server_status_updated.clear()
+        self.logger.debug("Waiting for status after connect")
         self._threading_events.server_status_updated.wait(timeout=timeout)
 
         if not self._threading_events.server_status_updated.is_set():

--- a/scrutiny/sdk/client.py
+++ b/scrutiny/sdk/client.py
@@ -1341,7 +1341,12 @@ class ScrutinyClient:
             raise sdk.exceptions.TimeoutException(f'Did not receive a Welcome message from the server. Timeout={self._timeout}s')
 
         if wait_status:
-            self.wait_server_status_update()
+            # Same logic as wait_server_status_update(), but without clearing the flag since we want at least 1 update.
+            timeout = self._UPDATE_SERVER_STATUS_INTERVAL + 2
+            self._threading_events.server_status_updated.wait(timeout=timeout)
+            if not self._threading_events.server_status_updated.is_set():
+                raise sdk.exceptions.TimeoutException(f"Server status did not update within a {timeout} seconds delay")
+            
         return self
 
     def disconnect(self) -> None:

--- a/scrutiny/sdk/client.py
+++ b/scrutiny/sdk/client.py
@@ -1567,7 +1567,6 @@ class ScrutinyClient:
         """
         timeout = validation.assert_float_range(timeout, 'timeout', minval=0)
         self._threading_events.server_status_updated.clear()
-        self.logger.debug("Waiting for status after connect")
         self._threading_events.server_status_updated.wait(timeout=timeout)
 
         if not self._threading_events.server_status_updated.is_set():

--- a/scrutiny/sdk/client.py
+++ b/scrutiny/sdk/client.py
@@ -761,6 +761,7 @@ class ScrutinyClient:
         if self._request_status_timer.is_timed_out() or self._require_status_update:
             self._require_status_update = False
             self._request_status_timer.stop()
+            self.logger.debug("Requesting server status update")
             req = self._make_request(API.Command.Client2Api.GET_SERVER_STATUS)
             self._send(req)  # No callback, we have a continuous listener
 

--- a/scrutiny/sdk/client.py
+++ b/scrutiny/sdk/client.py
@@ -341,7 +341,7 @@ class ScrutinyClient:
             """The firmware ID that matches the SFD"""
 
             def msg(self) -> str:
-                return f"Server has loaded a Firmware Decription with firmware ID: {self.firmware_id}"
+                return f"Server has loaded a Firmware Description with firmware ID: {self.firmware_id}"
 
         @dataclass(frozen=True)
         class SFDUnLoadedEvent:
@@ -351,7 +351,7 @@ class ScrutinyClient:
             """The firmware ID that matches the SFD"""
 
             def msg(self) -> str:
-                return f"Server has unloaded a Firmware Decription with firmware ID: {self.firmware_id}"
+                return f"Server has unloaded a Firmware Description with firmware ID: {self.firmware_id}"
 
         @dataclass(frozen=True)
         class DataloggingStateChanged:
@@ -487,7 +487,7 @@ class ScrutinyClient:
     _active_batch_context: Optional[BatchWriteContext]  # The active write batch. All writes are appended to it if not None
 
     _listeners: List[listeners.BaseListener]   # List of registered listeners
-    _event_queue: "queue.Queue[Events._ANY_EVENTS]"  # A queue containing all the events lsitened for
+    _event_queue: "queue.Queue[Events._ANY_EVENTS]"  # A queue containing all the events listened for
     _enabled_events: int                             # Flags indicating what events to listen for
     _datarate_measurements: DataRateMeasurements     # A measurement of the datarate with the server
     _server_timebase: RelativeTimebase          # A timebase that can convert server precise timings to unix timestamp.
@@ -2215,7 +2215,7 @@ class ScrutinyClient:
         :raise TypeError: Given parameter not of the expected type
         :raise OperationFailure: If the command completion fails
 
-        :return: A dictionnary containing the number of watchables, classified by type
+        :return: A dictionary containing the number of watchables, classified by type
         """
         req = self._make_request(API.Command.Client2Api.GET_WATCHABLE_COUNT)
 


### PR DESCRIPTION
Fixed race condition that could hang the client for 2 seconds after connecting the ScrutinyClient. The server status was received before we started to wait for the first update. Was waiting for the 2nd update.   Now doesn't wait if already received.

This problem was what has been slowing down the unit tests years now. yay!