### PR TITLE
Fix unit test that could hang

### DIFF
--- a/scrutiny/server/api/dummy_client_handler.py
+++ b/scrutiny/server/api/dummy_client_handler.py
@@ -37,7 +37,7 @@ class DummyConnection:
         else:
             self.conn_id = uuid.uuid4().hex
 
-        self.client_to_server_queue = queue.Queue()
+        self.client_to_server_queue = queue.Queue(maxsize=50)
         self.server_to_client_queue = queue.Queue(maxsize=50)
         self.opened = False
 

--- a/test/integration/integration_test.py
+++ b/test/integration/integration_test.py
@@ -184,11 +184,8 @@ class ScrutinyIntegrationTest(ScrutinyUnitTest):
     def empty_api_rx_queue(self):
         self.server.process()
         while self.api_conn.from_server_available():
-            print("before:%d" % self.api_conn.server_to_client_queue.qsize(), flush=True)
             self.api_conn.read_from_server()
-            self.server.process()
-            self.server.process()
-            print("after:%d" % self.api_conn.server_to_client_queue.qsize(), flush=True)
+        self.server.process()
 
     def spinwait_for(self, timeout):
         t1 = time.monotonic()


### PR DESCRIPTION
- When the test machine is running slowly, the emulated device could respond and keep the server-client queue non-empty for a long time