### PR TITLE
Fixed special regions not cleared when switching device

### DIFF
--- a/scrutiny/server/device/device_handler.py
+++ b/scrutiny/server/device/device_handler.py
@@ -72,7 +72,7 @@ class DeviceHandlerConfig(TypedDict, total=False):
     """Amount of time to wait before considering that a request has timed out"""
 
     heartbeat_timeout: float
-    """Time interval in between Heartbeat request. This value will be 
+    """Time interval in between Heartbeat request. This value will be
     overridden if the device requires a smaller interval"""
 
     default_address_size: int
@@ -97,7 +97,7 @@ class DeviceHandlerConfig(TypedDict, total=False):
     """The type of communication link to use to talk with a device. udp, serial, dummy, etc"""
 
     link_config: LinkConfig
-    """The configuration dictionary that will configure the communication link layer. 
+    """The configuration dictionary that will configure the communication link layer.
     Unique for each type of link (udp, serial, etc)"""
 
 
@@ -592,6 +592,8 @@ class DeviceHandler:
 
         max_request_payload_size = self.config['max_request_size']
         max_response_payload_size = self.config['max_response_size']
+        self.memory_reader.clear_config()
+        self.memory_writer.clear_config()
         self.memory_reader.set_size_limits(max_request_payload_size=max_request_payload_size, max_response_payload_size=max_response_payload_size)
         self.memory_writer.set_size_limits(max_request_payload_size=max_request_payload_size, max_response_payload_size=max_response_payload_size)
         self.dispatcher.set_size_limits(max_request_payload_size=max_request_payload_size, max_response_payload_size=max_response_payload_size)

--- a/scrutiny/server/device/submodules/memory_reader.py
+++ b/scrutiny/server/device/submodules/memory_reader.py
@@ -39,7 +39,7 @@ RawMemoryReadRequestCompletionCallback = Callable[["RawMemoryReadRequest", bool,
 
 
 class RawMemoryReadRequest:
-    """An internal structure used to define a raw memory read, meaning a read not tied to a datastore entry. 
+    """An internal structure used to define a raw memory read, meaning a read not tied to a datastore entry.
     Just the user that wants to dump the content"""
 
     __slots__ = ('address', 'size', 'completed', 'success', 'completion_callback', 'completion_server_time_us')
@@ -113,7 +113,7 @@ class DataStoreEntrySortableByAddress(Generic[T]):
 
 
 class DataStoreEntrySortableByRpvId:
-    """Wrapper around DatastoreRPVEntry that can be sorted by RPV ID. 
+    """Wrapper around DatastoreRPVEntry that can be sorted by RPV ID.
     Used to feed a SortedSet"""
 
     __slots__ = ('entry', )
@@ -288,6 +288,7 @@ class MemoryReader(BaseDeviceHandlerSubmodule):
 
     def start(self) -> None:
         """Enable the memory reader to poll the devices"""
+        self.logger.debug("Start requested")
         self.started = True
 
     def stop(self) -> None:

--- a/scrutiny/server/device/submodules/memory_writer.py
+++ b/scrutiny/server/device/submodules/memory_writer.py
@@ -36,7 +36,7 @@ RawMemoryWriteRequestCompletionCallback = Callable[["RawMemoryWriteRequest", boo
 
 
 class RawMemoryWriteRequest:
-    """An internal structure used to define a raw memory write, meaning a read not tied to a datastore entry. 
+    """An internal structure used to define a raw memory write, meaning a read not tied to a datastore entry.
     Just the user that wants to dump the content"""
 
     address: int
@@ -69,7 +69,7 @@ class RawMemoryWriteRequest:
 
 
 class MemoryWriter(BaseDeviceHandlerSubmodule):
-    """Class that request the device for its memory content or RPV to me modified according to 
+    """Class that request the device for its memory content or RPV to me modified according to
     either a datastore entry value or a raw value requested by the user
     It treats Variable and RuntimePublishedValues differently as they use a different protocol command.
     """
@@ -150,7 +150,7 @@ class MemoryWriter(BaseDeviceHandlerSubmodule):
             self.logger.warning('Adding a forbidden region with non strictly positive size %d' % size)
 
     def add_readonly_region(self, start_addr: int, size: int) -> None:
-        """Add a memory region that can only be read. We will avoid any write to them. 
+        """Add a memory region that can only be read. We will avoid any write to them.
         They normally are broadcasted by the device itself"""
         if size > 0:
             self.readonly_regions.append(MemoryRegion(start=start_addr, size=size))
@@ -170,6 +170,7 @@ class MemoryWriter(BaseDeviceHandlerSubmodule):
     def start(self) -> None:
         """Enable the memory writer to poll the datastore and update the device"""
         self.started = True
+        self.logger.debug("Start requested")
 
     def stop(self) -> None:
         """Stops the memory writer from polling the datastore and updating the device"""
@@ -201,7 +202,7 @@ class MemoryWriter(BaseDeviceHandlerSubmodule):
         self.clear_active_entry_write_request()
         self.clear_active_raw_write_request()
 
-    def _clear_config(self) -> None:
+    def clear_config(self) -> None:
         """Erase the configuration coming from the device handler"""
         self.max_request_payload_size = self.DEFAULT_MAX_REQUEST_PAYLOAD_SIZE
         self.max_response_payload_size = self.DEFAULT_MAX_RESPONSE_PAYLOAD_SIZE
@@ -224,7 +225,7 @@ class MemoryWriter(BaseDeviceHandlerSubmodule):
     def reset(self) -> None:
         """Put back the memory writer to its startup state"""
         self.set_standby()
-        self._clear_config()
+        self.clear_config()
 
     def would_send_data(self) -> bool:
         if not self.started:


### PR DESCRIPTION
- Switching device would leave read-only and forbidden regions untouched. Visible after using the demo mode