### PR TITLE
Remove the broadcast on watch feature introduced in #308

### DIFF
--- a/scrutiny/sdk/listeners/__init__.py
+++ b/scrutiny/sdk/listeners/__init__.py
@@ -268,11 +268,6 @@ class BaseListener(abc.ABC):
             for watchable in watchables:
                 self._subscriptions.add(watchable)
 
-        # Broadcast a first value upon subscription.
-        # Important: The server broadcast invalid values once, and it may have happened before the call to subscribe()
-        if self._started:
-            self._initial_broadcast(watchables)
-
     def unsubscribe(self, watchables: Union[WatchableHandle, Iterable[WatchableHandle]]) -> None:
         """Remove one or many watchables from the list of monitored watchables.
 
@@ -330,14 +325,7 @@ class BaseListener(abc.ABC):
             self._logger.debug("Started")
             self._started = True
 
-        # Initial value update on start. Will broadcast the last value received before the start() call.
-        self._initial_broadcast(self._subscriptions)
-
         return self
-
-    def _initial_broadcast(self, watchables: Iterable[WatchableHandle]) -> None:
-        filtered = [w for w in watchables if not w.is_dead and w.status != ValueStatus.NeverSet]
-        self._broadcast_update(filtered)
 
     def stop(self) -> None:
         """Stops the listener thread"""

--- a/scrutiny/server/datastore/datastore.py
+++ b/scrutiny/server/datastore/datastore.py
@@ -56,7 +56,6 @@ class Datastore:
     _batch_edit_callbacks: List[BatchEditCallback]
     _batch_edit_source_state: Dict[str, BatchState]
     _display_path_to_templated_entries_map: Dict[WatchableType, Dict[str, DatastoreEntry]]
-    _pending_call_queue: List[Callable[[], None]]
 
     MAX_ENTRY: int = 1000000
 
@@ -73,7 +72,6 @@ class Datastore:
         self._target_update_request_queue = []
         self._batch_edit_callbacks = []
         self._batch_edit_source_state = {}
-        self._pending_call_queue = []
         for watchable_type in WatchableType.all():
             self._entries[watchable_type] = {}
             self._watcher_map[watchable_type] = {}
@@ -305,17 +303,6 @@ class Datastore:
                     watcher=self._make_owner_from_entry(entry),
                     value_change_callback=pointer_value_change_callback
                 )
-
-        # If the value is already invalid, we tell the watcher right away.
-        # We do not stream an invalid value each time it is confirmed to be invalid.
-        # Only when the reason changes
-        if value_change_callback is not None:
-            invalid_reason = entry.get_value_invalid_reason()
-            if invalid_reason is None:  # Valid value
-                self._pending_call_queue.append(functools.partial(value_change_callback, watcher, entry))
-            elif invalid_reason != DatastoreEntryInvalidReason.NeverSet:    # Invalid, but set.
-                self._pending_call_queue.append(functools.partial(value_change_callback, watcher, entry))
-
         return entry
 
     def is_watching(self, entry_or_entryid: Union[DatastoreEntry, str], watcher: str) -> bool:
@@ -483,13 +470,6 @@ class Datastore:
     def get_all_variable_factory(self) -> Generator[VariableFactory, None, None]:
         for factory in self._var_factories.values():
             yield factory
-
-    def process(self) -> None:
-        # Callbacks that needs to eb executed outside of a callback.
-        # Equivalent to QT QueuedConnection
-        while len(self._pending_call_queue) > 0:
-            callback = self._pending_call_queue.pop()
-            callback()
 
 # region Private
 

--- a/scrutiny/server/datastore/datastore_entry.py
+++ b/scrutiny/server/datastore/datastore_entry.py
@@ -254,12 +254,10 @@ class DatastoreEntry(abc.ABC):
          the datastore as callbacks are meant to propagate the update to the user (API side)"""
         if invalid_reason is not None:
             assert value is None    # We require a value to be None to be invalid
-        previous_invalid_reason = self.invalid_reason
         self.value = value
         self.invalid_reason = invalid_reason
         self.last_value_update_server_time_us = server_timebase.get_micro()
-        if invalid_reason is None or invalid_reason != previous_invalid_reason:
-            self.execute_value_change_callback()
+        self.execute_value_change_callback()
 
     def get_value_change_server_time_us(self) -> float:
         """Returns the timestamp of the last value update made to this entry """

--- a/scrutiny/server/server.py
+++ b/scrutiny/server/server.py
@@ -149,7 +149,6 @@ class ScrutinyServer:
     def process(self) -> None:
         self.api.process()
         self.datalogging_manager.process()
-        self.datastore.process()
         self.device_handler.process()
         self.sfd_handler.process()
 

--- a/test/gui/test_server_manager.py
+++ b/test/gui/test_server_manager.py
@@ -759,7 +759,6 @@ class TestServerManagerRegistryInteraction(ScrutinyBaseGuiTest):
         watch_request.simulate_success(watch1_config)
 
         self.wait_true_with_events(lambda: self.fake_client.watch_handle_exists(varpath), 2)
-        self.wait_true_with_events(lambda: len(all_updates) == 1, timeout=2)
 
         watch1 = self.fake_client.try_get_existing_watch_handle(varpath)
         self.assertIsNotNone(watch1)
@@ -768,13 +767,11 @@ class TestServerManagerRegistryInteraction(ScrutinyBaseGuiTest):
 
         all_updates.clear()
         self.server_manager._listener.subscribe(watch1)                     # Will broadcast
-        self.wait_true_with_events(lambda: len(all_updates) == 1, timeout=2)
         self.server_manager._listener._broadcast_update([watch1])           # broadcast too
 
-        self.wait_true_with_events(lambda: len(all_updates) >= 2, timeout=2)
-        self.assertEqual(len(all_updates), 2)
+        self.wait_true_with_events(lambda: len(all_updates) >= 1, timeout=2)
+        self.assertEqual(len(all_updates), 1)
         self.assertEqual(all_updates[0].sdk_update.value, 1234)
-        self.assertEqual(all_updates[1].sdk_update.value, 1234)
 
     def test_server_id_association_maintained_properly(self):
         varpath = '/aaa/bbb/ccc'
@@ -867,9 +864,7 @@ class TestQtListener(ScrutinyBaseGuiTest):
         # Listener is started, these will trigger a broadcast
         self.listener.subscribe(self.watch1)
         self.listener.subscribe(self.watch3)
-        self.wait_true_with_events(lambda: len(data_received) >= 2, timeout=2)   # Wait for callback to be called through a QT signal
-        self.assertEqual(counter.count, 1)
-        data_received.clear()
+        self.assertEqual(counter.count, 0)
         self.listener.ready_for_next_update()
 
         # Simulate what the client does. Date comes in from the network
@@ -877,7 +872,7 @@ class TestQtListener(ScrutinyBaseGuiTest):
 
         self.wait_true_with_events(lambda: len(data_received) >= 2, timeout=2)   # Wait for callback to be called through a QT signal
         self.assertEqual(len(data_received), 2)
-        self.assertEqual(counter.count, 2)
+        self.assertEqual(counter.count, 1)
         self.assertIs(data_received[0].watchable, self.watch1)
         # watch2 was not subscribed
         self.assertIs(data_received[1].watchable, self.watch3)
@@ -889,13 +884,13 @@ class TestQtListener(ScrutinyBaseGuiTest):
         # We have not authorized the listener to emit a new QT signal. So no callback called.
         self.assertGreater(self.listener.gui_qsize, 0)  # Enqueued, waiting for callback to empty it
         self.assertEqual(len(data_received), 0)
-        self.assertEqual(counter.count, 2)
+        self.assertEqual(counter.count, 1)
         self.listener.ready_for_next_update()
 
         # Now that we authorized it, a new QT signal will be emitted so that we empty the gui_queue
         self.wait_true_with_events(lambda: len(data_received) >= 2, timeout=2)
         self.assertEqual(len(data_received), 2)
-        self.assertEqual(counter.count, 3)
+        self.assertEqual(counter.count, 2)
         self.assertIs(data_received[0].watchable, self.watch1)
         # watch2 was not subscribed
         self.assertIs(data_received[1].watchable, self.watch3)

--- a/test/sdk/test_listeners.py
+++ b/test/sdk/test_listeners.py
@@ -663,31 +663,6 @@ class TestListeners(ScrutinyUnitTest):
                 )
                 listener.start()
 
-    def test_initial_broadcast_on_start(self):
-        listener = WorkingTestListener()
-        listener.subscribe([self.w1, self.w2, self.w3, self.w4])
-        with listener.start():
-            time.sleep(1)
-            self.assertEqual(listener.update_count, 0)  # All NeverSet. Should receive nothing
-
-        # Set 2 of them w1 and w2
-        self.w1._set_invalid(sdk.ValueStatus.NullPtrDereferenced)
-        self.w2._update_value(123)
-
-        listener = WorkingTestListener()
-        listener.subscribe([self.w1, self.w2, self.w3, self.w4])
-        with listener.start():
-            wait_cond(lambda: listener.update_count >= 2, 1)   # Hope to receive 2 updates. w1 and w2
-            self.assertEqual(listener.update_count, 2)
-
-        listener = WorkingTestListenerAllowSubscriptionChange()
-        with listener.start():
-            time.sleep(0.5)
-            self.assertEqual(listener.update_count, 0)
-            listener.subscribe([self.w1, self.w2, self.w3, self.w4])
-            wait_cond(lambda: listener.update_count >= 2, 1)   # Hope to receive 2 updates. w1 and w2
-            self.assertEqual(listener.update_count, 2)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/server/test_datastore.py
+++ b/test/server/test_datastore.py
@@ -589,7 +589,7 @@ class TestDataStore(ScrutinyUnitTest):
             self.assertNotIn(hash(entry), hash_set)
             hash_set.add(hash(entry))
 
-    def test_invoke_callback_on_invalid_change_only(self):
+    def test_invoke_callback_on_invalid_set(self):
         ds = Datastore()
         entries = list(self.make_dummy_entries(3, WatchableType.Variable))
         ds.add_entries(entries)
@@ -598,23 +598,21 @@ class TestDataStore(ScrutinyUnitTest):
         ds.start_watching(entries[0], 'unittest', value_change_callback=self.value_change_callback)
         ds.start_watching(entries[1], 'unittest', value_change_callback=self.value_change_callback)
         ds.start_watching(entries[2], 'unittest', value_change_callback=self.value_change_callback)
-        ds.process()
 
-        self.assertValueChangeCallbackCalled(entries[0].entry_id, 'unittest', 1)
-        self.assertValueChangeCallbackCalled(entries[1].entry_id, 'unittest', 1)
+        self.assertValueChangeCallbackCalled(entries[0].entry_id, 'unittest', 0)
+        self.assertValueChangeCallbackCalled(entries[1].entry_id, 'unittest', 0)
         self.assertValueChangeCallbackCalled(entries[2].entry_id, 'unittest', 0)
 
         entries[1].set_value(None, DatastoreEntryInvalidReason.ForbiddenRegion)
         entries[1].set_value(None, DatastoreEntryInvalidReason.ForbiddenRegion)
         entries[1].set_value(None, DatastoreEntryInvalidReason.ForbiddenRegion)
         entries[1].set_value(None, DatastoreEntryInvalidReason.ForbiddenRegion)
+        self.assertValueChangeCallbackCalled(entries[1].entry_id, 'unittest', 4)
 
-        self.assertValueChangeCallbackCalled(entries[1].entry_id, 'unittest', 1)
         entries[1].set_value(None, DatastoreEntryInvalidReason.NullPtrDereference)
         entries[1].set_value(None, DatastoreEntryInvalidReason.NullPtrDereference)
         entries[1].set_value(None, DatastoreEntryInvalidReason.NullPtrDereference)
-        entries[1].set_value(None, DatastoreEntryInvalidReason.NullPtrDereference)
-        self.assertValueChangeCallbackCalled(entries[1].entry_id, 'unittest', 2)
+        self.assertValueChangeCallbackCalled(entries[1].entry_id, 'unittest', 7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- #308 introduced a feature that broadcast the last value before a watch to the client on watch start. Causes more issues than benefits. This PR removes that.