### PR TITLE
Fix watchable registry bug that could assign same ID to different elements

### DIFF
--- a/scrutiny/gui/core/watchable_registry.py
+++ b/scrutiny/gui/core/watchable_registry.py
@@ -138,7 +138,6 @@ class WatchableRegistryEntryNode:
         self._watcher_count = 0
         self.registry_id = registry._make_node_id()
 
-
 @dataclass(frozen=True, slots=True)
 class WatchableRegistryIntermediateNode:
     """An intermediate node that contains watchable and other subnodes"""
@@ -721,8 +720,8 @@ class WatchableRegistry:
         total_remaining_data = 0
         for t in sdk.WatchableType.all():
             total_remaining_data += self.get_watchable_count(t)
-            if total_remaining_data == 0:
-                self._node_counter = 0  # Avoid growing forever
+        if total_remaining_data == 0:
+            self._node_counter = 0  # Avoid growing forever
 
         return changed
 

--- a/test/gui/test_watchable_registry.py
+++ b/test/gui/test_watchable_registry.py
@@ -828,21 +828,27 @@ class TestWatchableRegistry(ScrutinyUnitTest):
             sdk.WatchableType.RuntimePublishedValue: DUMMY_DATASET_RPV
         }
 
-        for i in range(2):
-            self.registry.write_content(content_rpv)
-            self.registry.write_content(content_var_alias)
-            self.registry.clear_content_by_type(sdk.WatchableType.RuntimePublishedValue)
-            self.registry.write_content(content_rpv)
-
+        def validate_id_unique():
             seen_ids = set()
             for watchable_type, content in All_DUMMY_DATA.items():
                 for path, config in content.items():
                     node = self.registry.get_watchable_node(watchable_type, path)
+                    if node is not None:
+                        self.assertNotIn(node.registry_id, seen_ids)
+                        seen_ids.add(node.registry_id)
 
-                    self.assertNotIn(node.registry_id, seen_ids, f"i={i}")
-                    seen_ids.add(node.registry_id)
 
+        for i in range(2):
+            self.registry.write_content(content_rpv)
+            validate_id_unique()
+            self.registry.write_content(content_var_alias)
+            validate_id_unique()
+            self.registry.clear_content_by_type(sdk.WatchableType.RuntimePublishedValue)
+            validate_id_unique()
+            self.registry.write_content(content_rpv)
+            validate_id_unique()
             self.registry.clear_content_by_type([sdk.WatchableType.RuntimePublishedValue, sdk.WatchableType.Alias, sdk.WatchableType.Variable])
+            validate_id_unique()
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
- When doing a partial clear of the registry, the Id counter would reset to 0 even if elements were still in it.