### PR TITLE
HMI - Support mouse hovering and hit test logic

### DIFF
--- a/.codebanner.json
+++ b/.codebanner.json
@@ -1112,6 +1112,9 @@
         },
         "scrutiny/gui/components/locals/hmi/hmi_widgets/display/linear_gauge_hmi_widget.py": {
             "docstring": "An HMI widget that display a value with a linear gauge that goes from a minimum to a maximum value. Like a progress bar"
+        },
+        "scrutiny/gui/components/locals/hmi/common/hit_zones.py": {
+            "docstring": "Hit test logic for various shapes. Contains shared logic between HMI widgets"
         }
     },
     "authors": {}

--- a/scrutiny/gui/components/locals/hmi/common/hit_zones.py
+++ b/scrutiny/gui/components/locals/hmi/common/hit_zones.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from PySide6.QtCore import QPointF, QRectF
+
+__all__ = ['BaseHitZone', 'EllipseHitZone', 'RectHitZone']
+
+
+class BaseHitZone:
+    def hit_test(self, pos: QPointF) -> bool:
+        raise NotImplementedError("Virtual method")
+
+
+@dataclass(slots=True)
+class EllipseHitZone(BaseHitZone):
+    center: QPointF
+    radius_w: float
+    radius_h: float
+
+    def hit_test(self, pos: QPointF) -> bool:
+        if self.radius_w <= 0 or self.radius_h <= 0:
+            return False
+
+        term1 = (pos.x() - self.center.x())**2 / self.radius_w**2
+        term2 = (pos.y() - self.center.y())**2 / self.radius_h**2
+        return (term1 + term2 <= 1)
+
+
+@dataclass(slots=True)
+class RectHitZone(BaseHitZone):
+    rect: QRectF
+
+    def hit_test(self, pos: QPointF) -> bool:
+        return self.rect.contains(pos)

--- a/scrutiny/gui/components/locals/hmi/common/hit_zones.py
+++ b/scrutiny/gui/components/locals/hmi/common/hit_zones.py
@@ -1,3 +1,11 @@
+#    hit_zones.py
+#        Hit test logic for various shapes. Contains shared logic between HMI widgets
+#
+#   - License : MIT - See LICENSE file
+#   - Project : Scrutiny Debugger (github.com/scrutinydebugger/scrutiny-main)
+#
+#    Copyright (c) 2026 Scrutiny Debugger
+
 from dataclasses import dataclass
 from PySide6.QtCore import QPointF, QRectF
 

--- a/scrutiny/gui/components/locals/hmi/hmi_component.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_component.py
@@ -383,13 +383,13 @@ class HMIComponent(ScrutinyGUIBaseLocalComponent):
             self._show_edit_menu(True)
             self._workzone.show_grid(True)
             self._workzone.setAcceptDrops(True)
-            self._workzone.set_allow_edit_widgets(True)
+            self._workzone.set_edit_mode(True)
             self._status_bar.setVisible(True)
         elif self._mode == HMIInteractionMode.Display:
             self._show_edit_menu(False)
             self._workzone.show_grid(False)
             self._workzone.setAcceptDrops(False)
-            self._workzone.set_allow_edit_widgets(False)
+            self._workzone.set_edit_mode(False)
             self._status_bar.setVisible(False)
 
         for hmi_widget in self._workzone.iterate_hmi_widgets():

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/base_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/base_hmi_widget.py
@@ -16,7 +16,7 @@ import enum
 
 from PySide6.QtWidgets import QWidget, QFormLayout, QGraphicsItem, QStyleOptionGraphicsItem
 from PySide6.QtGui import QPainter, QPixmap, QIcon
-from PySide6.QtCore import QSize, QRectF, QPointF, QObject, Qt, Signal
+from PySide6.QtCore import QSize, QRectF, QPointF, QPoint, QObject, Qt, Signal
 
 from scrutiny import sdk
 from scrutiny.gui.app_settings import app_settings
@@ -584,7 +584,6 @@ class BaseHMIWidget(QGraphicsItem):
 
 # region Private
 
-
     def _write_callback_wrapper(self,
                                 vslot: ValueSlot,
                                 override_id: int,
@@ -737,11 +736,17 @@ class BaseHMIWidget(QGraphicsItem):
 
         self._last_draw_timestamp_ns = time.perf_counter_ns()
 
-    def left_mouse_down(self, pos: QPointF) -> None:
-        pass
+    def left_mouse_down(self, pos: QPointF) -> Qt.CursorShape:
+        return Qt.CursorShape.ArrowCursor
 
-    def left_mouse_up(self, pos: Optional[QPointF]) -> None:
-        pass
+    def left_mouse_up(self, pos: Optional[QPointF]) -> Qt.CursorShape:
+        return Qt.CursorShape.ArrowCursor
+
+    def mouse_move(self, pos: QPointF) -> Qt.CursorShape:
+        return Qt.CursorShape.ArrowCursor
+
+    def hit_test(self, pos: QPointF) -> bool:
+        return self.boundingRect().contains(pos)
 
 # region Abstracts methods
 

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/base_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/base_hmi_widget.py
@@ -24,6 +24,7 @@ from scrutiny.gui.widgets.watchable_line_edit import WatchableLineEdit, Watchabl
 from scrutiny.gui.components.locals.hmi.hmi_library_category import LibraryCategory
 from scrutiny.gui.components.locals.hmi.hmi_edit_grid import HMIEditGrid
 from scrutiny.gui.components.locals.hmi.hmi_theme import HMITheme
+from scrutiny.gui.components.locals.hmi.common.hit_zones import BaseHitZone
 from scrutiny.gui.core.watchable_registry import WatcherIdType, RegistryValueUpdate, WatchableRegistry, WatchableRegistryNodeNotFoundError
 from scrutiny.gui.component_app_interface import AbstractComponentAppInterface
 from scrutiny.gui.tools.invoker import invoke_later
@@ -87,6 +88,7 @@ class ValueSlot:
     value_update_callback: Optional[HMIWidgetValueUpdateCallback]
     """A callback to be called on value update. Mostly useful when require_redraw=``False``"""
     value_override: Optional[ValueOverride]
+    """When set, overrides the watchable value reading with this value. Used to avoid visual glitches while writes are in progress"""
     _signals: _Signals
     """The QT signals"""
     _logger: logging.Logger
@@ -303,6 +305,8 @@ class BaseHMIWidget(QGraphicsItem):
     _instance_id: int
     """A monotonic unique number assigned to the HMI widget"""
     _del_callback: List[Callable[[], None]]
+    """A list of callbacks to call when this object is garbage collected."""
+    _hit_zone: Optional[BaseHitZone]
 
     def __init__(self, app: AbstractComponentAppInterface) -> None:
         super().__init__()
@@ -323,6 +327,7 @@ class BaseHMIWidget(QGraphicsItem):
         self._edit_select_frame = EditSelectFrame(self)
         self._edit_select_frame.setZValue(100000)
         self._selection_overlay.setZValue(self._edit_select_frame.zValue() - 1)
+        self._hit_zone = None
         self.set_selected(False)
         self.set_edit_mode(False)
 
@@ -581,8 +586,16 @@ class BaseHMIWidget(QGraphicsItem):
             raise RuntimeError("ValueSlot is not in watchable mode")
         return vslot.watchable_line_edit.get_watchable()
 
+    def hit_test(self, pos: QPointF) -> bool:
+        if self._hit_zone is None:
+            return self.boundingRect().contains(pos)
+        else:
+            return self._hit_zone.hit_test(pos)
 
 # region Private
+    def _set_hit_zone(self, zone: Optional[BaseHitZone]) -> None:
+        """To be called by child HMI widget"""
+        self._hit_zone = zone
 
     def _write_callback_wrapper(self,
                                 vslot: ValueSlot,
@@ -744,9 +757,6 @@ class BaseHMIWidget(QGraphicsItem):
 
     def mouse_move(self, pos: QPointF) -> Qt.CursorShape:
         return Qt.CursorShape.ArrowCursor
-
-    def hit_test(self, pos: QPointF) -> bool:
-        return self.boundingRect().contains(pos)
 
 # region Abstracts methods
 

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/controls/button_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/controls/button_hmi_widget.py
@@ -12,9 +12,9 @@ __all__ = ['ButtonHMIWidget']
 import enum
 import math
 
-from PySide6.QtGui import QPainter, QPen, QBrush
+from PySide6.QtGui import QPainter, QPainterPath, QPen, QBrush
 from PySide6.QtCore import QSize, Qt, QPointF, QRectF, QSizeF
-from PySide6.QtWidgets import QVBoxLayout, QWidget, QGroupBox, QComboBox, QFormLayout, QLineEdit
+from PySide6.QtWidgets import QGraphicsSceneMouseEvent, QVBoxLayout, QWidget, QGroupBox, QComboBox, QFormLayout, QLineEdit
 
 from scrutiny.gui.component_app_interface import AbstractComponentAppInterface
 from scrutiny.gui.components.locals.hmi.hmi_widgets.base_hmi_widget import BaseHMIWidget, WatchableValueType
@@ -183,6 +183,10 @@ class ButtonHMIWidget(BaseHMIWidget):
     def get_config_widget(self) -> QWidget:
         return self._config_widget
 
+    def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+        print("move")
+        return super().mouseMoveEvent(event)
+
     def draw(self,
              values: Dict[str, Optional[WatchableValueType]],
              edit_mode: bool,
@@ -206,7 +210,7 @@ class ButtonHMIWidget(BaseHMIWidget):
 
         if not is_valid:
             text = ""
-            brush.setColor(HMITheme.Color.text_display_background())
+            brush.setColor(HMIColor.INACTIVE.to_qcolor())
         else:
             if is_active:
                 brush.setColor(cast(HMIColor, self._cmb_color_active.currentData()).to_qcolor())
@@ -316,7 +320,7 @@ class ButtonHMIWidget(BaseHMIWidget):
             and valid_color_inactive
         )
 
-    def left_mouse_down(self, pos: QPointF) -> None:
+    def left_mouse_down(self, pos: QPointF) -> Qt.CursorShape:
         self._is_pressed = True
         if self.get_button_type() == ButtonType.MOMENTARY:
             self._write_val(True)
@@ -329,8 +333,9 @@ class ButtonHMIWidget(BaseHMIWidget):
             raise NotImplementedError("Unknown button type")    # pragma: no cover
 
         self.update()
+        return Qt.CursorShape.PointingHandCursor
 
-    def left_mouse_up(self, pos: Optional[QPointF]) -> None:
+    def left_mouse_up(self, pos: Optional[QPointF]) -> Qt.CursorShape:
         if self.get_button_type() == ButtonType.MOMENTARY:
             self._write_val(False)
         elif self.get_button_type() == ButtonType.TOGGLE:
@@ -339,6 +344,9 @@ class ButtonHMIWidget(BaseHMIWidget):
             raise NotImplementedError("Unknown button type")    # pragma: no cover
         self._is_pressed = False
         self.update()
+        return Qt.CursorShape.PointingHandCursor
 
+    def mouse_move(self, pos: QPointF) -> Qt.CursorShape:
+        return Qt.CursorShape.PointingHandCursor
 
 # endregion

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/display/color_indicator_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/display/color_indicator_hmi_widget.py
@@ -19,6 +19,7 @@ from scrutiny.gui.component_app_interface import AbstractComponentAppInterface
 from scrutiny.gui.components.locals.hmi.hmi_widgets.base_hmi_widget import BaseHMIWidget, WatchableValueType
 from scrutiny.gui.components.locals.hmi.common.hmi_colors import HMIColor, create_color_combobox
 from scrutiny.gui.components.locals.hmi.common.serialization import deserialize_combobox_val
+from scrutiny.gui.components.locals.hmi.common.hit_zones import EllipseHitZone
 from scrutiny.gui import assets
 from scrutiny.tools.typing import *
 
@@ -223,14 +224,6 @@ class ColorIndicatorHMIWidget(BaseHMIWidget):
     def get_config_widget(self) -> QWidget:
         return self._config_widget
 
-    def hit_test(self, pos: QPointF) -> bool:
-        bounding_rect = self.boundingRect()
-        center = QPointF(bounding_rect.width() / 2, bounding_rect.height() / 2)
-        radius_w = _Dims.RADIUS * bounding_rect.width() / 2
-        radius_h = _Dims.RADIUS * bounding_rect.height() / 2
-
-        return ((pos.x() - center.x())**2 / radius_w**2 + (pos.y() - center.y())**2 / radius_h**2 <= 1)
-
     def draw(self,
              values: Dict[str, Optional[WatchableValueType]],
              edit_mode: bool,
@@ -245,6 +238,13 @@ class ColorIndicatorHMIWidget(BaseHMIWidget):
         inner_radius = (_Dims.RADIUS - _Dims.BORDER_W) * ref_width
         border_width = _Dims.BORDER_W * ref_width
         center = QPointF(bounding_rect.width() / 2, bounding_rect.height() / 2)
+
+        hit_zone = EllipseHitZone(
+            center=center,
+            radius_w=ref_width * _Dims.RADIUS,
+            radius_h=ref_width * _Dims.RADIUS * aspect_ratio
+        )
+        self._set_hit_zone(hit_zone)
 
         result = self._eval_condition(self._cmb_operator.currentData(), op1, op2)
         if result and not self._last_condition_eval_result:

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/display/color_indicator_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/display/color_indicator_hmi_widget.py
@@ -223,6 +223,14 @@ class ColorIndicatorHMIWidget(BaseHMIWidget):
     def get_config_widget(self) -> QWidget:
         return self._config_widget
 
+    def hit_test(self, pos: QPointF) -> bool:
+        bounding_rect = self.boundingRect()
+        center = QPointF(bounding_rect.width() / 2, bounding_rect.height() / 2)
+        radius_w = _Dims.RADIUS * bounding_rect.width() / 2
+        radius_h = _Dims.RADIUS * bounding_rect.height() / 2
+
+        return ((pos.x() - center.x())**2 / radius_w**2 + (pos.y() - center.y())**2 / radius_h**2 <= 1)
+
     def draw(self,
              values: Dict[str, Optional[WatchableValueType]],
              edit_mode: bool,

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/display/radial_gauge_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/display/radial_gauge_hmi_widget.py
@@ -55,6 +55,13 @@ class PointerAngle:
     clipped: bool
 
 
+@dataclass(slots=True)
+class HitTestData:
+    center: QPointF
+    radius_w: float
+    radius_h: float
+
+
 class _GaugePointer(QGraphicsItem):
     """The needle of the gauge"""
     _angle: float
@@ -151,6 +158,7 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
     _sld_label_size: QSlider
     """A slider to modulate the size of the tick labels between min and max size"""
 
+    _hit_test_data: HitTestData
     # State variables
     _minval: Optional[float]
     """The last minimum we have received (it's not a constant)"""
@@ -165,6 +173,7 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
 
         self._minval = None
         self._maxval = None
+        self._hit_test_data = HitTestData(QPointF(0, 0), 1, 1)
 
         self._numerical_display = NumericalTextDisplay(self)
         self._numerical_display.set_background_color(HMITheme.Color.workzone_background())  # Effect of hole
@@ -275,7 +284,6 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
 
 # region Getter & Setters
 
-
     def set_number_formatting_config(self, config: NumberFormattingConfig) -> None:
         self._numerical_display.set_number_formatting_config(config)
 
@@ -358,6 +366,10 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
         ref_size = bounding_rect.width() / 2
         center = QPointF(bounding_rect.width() / 2, bounding_rect.height() / 2)
         stroke_w = max(ref_size * _Dims.STROKE, 1)
+        self._hit_test_data.center = center
+        self._hit_test_data.radius_w = ref_size * _Dims.OUTER_CIRCLE
+        self._hit_test_data.radius_h = self._hit_test_data.radius_w * aspect_ratio
+
         outer_radius = ref_size * _Dims.OUTER_CIRCLE - stroke_w / 2
         inner_radius = ref_size * _Dims.INNER_CIRCLE - stroke_w / 2
         textbox_w = ref_size * _Dims.TEXT_DISPLAY_W
@@ -513,6 +525,14 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
         self._numerical_display.set_size(QSizeF(textbox_w, textbox_h).toSize())
 
         self._process_new_val(values['val'])
+
+    def hit_test(self, pos: QPointF) -> bool:
+        if self._hit_test_data.radius_w <= 0 or self._hit_test_data.radius_h <= 0:
+            return False
+
+        term1 = (pos.x() - self._hit_test_data.center.x())**2 / self._hit_test_data.radius_w**2
+        term2 = (pos.y() - self._hit_test_data.center.y())**2 / self._hit_test_data.radius_h**2
+        return (term1 + term2 <= 1)
 
     def get_config_widget(self) -> Optional[QWidget]:
         return self._config_widget

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/display/radial_gauge_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/display/radial_gauge_hmi_widget.py
@@ -25,6 +25,7 @@ from scrutiny.gui.components.locals.hmi.common.numerical_text_display import Num
 from scrutiny.gui.components.locals.hmi.common.color_span_editor import ColorSpanEditor, ColorSpanListStateDict, ColorSpan
 from scrutiny.gui.components.locals.hmi.common.gauge import GaugeOverflowBehavior
 from scrutiny.gui.components.locals.hmi.common.serialization import deserialize_combobox_val
+from scrutiny.gui.components.locals.hmi.common.hit_zones import EllipseHitZone
 from scrutiny.gui import assets
 from scrutiny import tools
 from scrutiny.tools.typing import *
@@ -53,13 +54,6 @@ class _Dims:
 class PointerAngle:
     angle: float
     clipped: bool
-
-
-@dataclass(slots=True)
-class HitTestData:
-    center: QPointF
-    radius_w: float
-    radius_h: float
 
 
 class _GaugePointer(QGraphicsItem):
@@ -158,7 +152,6 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
     _sld_label_size: QSlider
     """A slider to modulate the size of the tick labels between min and max size"""
 
-    _hit_test_data: HitTestData
     # State variables
     _minval: Optional[float]
     """The last minimum we have received (it's not a constant)"""
@@ -173,7 +166,6 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
 
         self._minval = None
         self._maxval = None
-        self._hit_test_data = HitTestData(QPointF(0, 0), 1, 1)
 
         self._numerical_display = NumericalTextDisplay(self)
         self._numerical_display.set_background_color(HMITheme.Color.workzone_background())  # Effect of hole
@@ -366,9 +358,12 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
         ref_size = bounding_rect.width() / 2
         center = QPointF(bounding_rect.width() / 2, bounding_rect.height() / 2)
         stroke_w = max(ref_size * _Dims.STROKE, 1)
-        self._hit_test_data.center = center
-        self._hit_test_data.radius_w = ref_size * _Dims.OUTER_CIRCLE
-        self._hit_test_data.radius_h = self._hit_test_data.radius_w * aspect_ratio
+        hit_zone = EllipseHitZone(
+            center=center,
+            radius_w=ref_size * _Dims.OUTER_CIRCLE,
+            radius_h=ref_size * _Dims.OUTER_CIRCLE * aspect_ratio
+        )
+        self._set_hit_zone(hit_zone)
 
         outer_radius = ref_size * _Dims.OUTER_CIRCLE - stroke_w / 2
         inner_radius = ref_size * _Dims.INNER_CIRCLE - stroke_w / 2
@@ -525,14 +520,6 @@ class RadialGaugeHMIWidget(BaseHMIWidget):
         self._numerical_display.set_size(QSizeF(textbox_w, textbox_h).toSize())
 
         self._process_new_val(values['val'])
-
-    def hit_test(self, pos: QPointF) -> bool:
-        if self._hit_test_data.radius_w <= 0 or self._hit_test_data.radius_h <= 0:
-            return False
-
-        term1 = (pos.x() - self._hit_test_data.center.x())**2 / self._hit_test_data.radius_w**2
-        term2 = (pos.y() - self._hit_test_data.center.y())**2 / self._hit_test_data.radius_h**2
-        return (term1 + term2 <= 1)
 
     def get_config_widget(self) -> Optional[QWidget]:
         return self._config_widget

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/graphics/circle_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/graphics/circle_hmi_widget.py
@@ -20,6 +20,7 @@ from scrutiny.tools.typing import *
 from scrutiny.gui.components.locals.hmi.hmi_library_category import LibraryCategory
 from scrutiny.gui.components.locals.hmi.common.pen_config import PenConfigWidget, PenConfigStateDict
 from scrutiny.gui.components.locals.hmi.common.brush_config import BrushConfigWidget, BrushConfigStateDict
+from scrutiny.gui.components.locals.hmi.common.hit_zones import EllipseHitZone
 
 
 class CircleHMIWidget(BaseHMIWidget):
@@ -91,6 +92,13 @@ class CircleHMIWidget(BaseHMIWidget):
             QPointF(pen.widthF() / 2, pen.widthF() / 2),
             QSizeF(bounding_rect.width() - pen.widthF(), bounding_rect.height() - pen.widthF())
         )
+
+        hit_zone = EllipseHitZone(
+            center=QPointF(bounding_rect.width() / 2, bounding_rect.height() / 2),
+            radius_w=bounding_rect.width() / 2,
+            radius_h=bounding_rect.height() / 2
+        )
+        self._set_hit_zone(hit_zone)
 
         painter.drawEllipse(draw_rect)
 

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/graphics/line_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/graphics/line_hmi_widget.py
@@ -9,7 +9,7 @@
 __all__ = ['LineHMIWidget']
 
 from PySide6.QtGui import QPainter, QPen
-from PySide6.QtCore import Qt, QPointF
+from PySide6.QtCore import Qt, QPointF, QRectF, QSizeF
 from PySide6.QtWidgets import QVBoxLayout, QWidget, QComboBox
 
 
@@ -20,6 +20,7 @@ from scrutiny.tools.typing import *
 
 from scrutiny.gui.components.locals.hmi.hmi_library_category import LibraryCategory
 from scrutiny.gui.components.locals.hmi.common.pen_config import PenConfigWidget, PenConfigStateDict
+from scrutiny.gui.components.locals.hmi.common.hit_zones import RectHitZone
 
 
 class LineHMIWidget(BaseHMIWidget):
@@ -30,27 +31,26 @@ class LineHMIWidget(BaseHMIWidget):
     _ICON = assets.Icons.HMILine
 
     _config_widget: QWidget
-    _cmb_direction: QComboBox
+    _cmb_orientation: QComboBox
     _pen_config: PenConfigWidget
 
     def __init__(self, app: AbstractComponentAppInterface) -> None:
         super().__init__(app)
-
         self._config_widget = QWidget()
         self._pen_config = PenConfigWidget()
         self._pen_config.set_width(5)
 
         layout = QVBoxLayout(self._config_widget)
-        self._cmb_direction = QComboBox()
-        self._cmb_direction.addItem("Vertical", Qt.Orientation.Vertical)
-        self._cmb_direction.addItem("Horizontal", Qt.Orientation.Horizontal)
-        self._cmb_direction.setCurrentIndex(self._cmb_direction.findData(Qt.Orientation.Horizontal))
+        self._cmb_orientation = QComboBox()
+        self._cmb_orientation.addItem("Vertical", Qt.Orientation.Vertical)
+        self._cmb_orientation.addItem("Horizontal", Qt.Orientation.Horizontal)
+        self._cmb_orientation.setCurrentIndex(self._cmb_orientation.findData(Qt.Orientation.Horizontal))
 
         layout.addWidget(self._pen_config)
-        layout.addWidget(self._cmb_direction)
+        layout.addWidget(self._cmb_orientation)
 
         self._pen_config.signals.changed.connect(self._update)
-        self._cmb_direction.currentIndexChanged.connect(self._update)
+        self._cmb_orientation.currentIndexChanged.connect(self._update)
 
     def _update(self, *args: Any, **kwargs: Any) -> None:
         self.update()
@@ -61,6 +61,15 @@ class LineHMIWidget(BaseHMIWidget):
 
     def get_border_pen(self) -> QPen:
         return self._pen_config.get_pen()
+
+    def set_orientation(self, orientation: Qt.Orientation) -> None:
+        index = self._cmb_orientation.findData(orientation)
+        if index >= 0:
+            self._cmb_orientation.setCurrentIndex(index)
+
+    def get_orientation(self) -> Qt.Orientation:
+        return cast(Qt.Orientation, self._cmb_orientation.currentData())
+
 # endregion
 
 # region Override
@@ -72,7 +81,7 @@ class LineHMIWidget(BaseHMIWidget):
              edit_mode: bool,
              painter: QPainter
              ) -> None:
-        orientation = cast(Qt.Orientation, self._cmb_direction.currentData())
+        orientation = cast(Qt.Orientation, self._cmb_orientation.currentData())
         bounding_rect = self.boundingRect()
         pen = self._pen_config.get_pen()
         pen.setCapStyle(Qt.PenCapStyle.FlatCap)
@@ -81,13 +90,25 @@ class LineHMIWidget(BaseHMIWidget):
             pen.setWidthF(line_w)
             p1 = QPointF(0, bounding_rect.height() / 2)
             p2 = QPointF(bounding_rect.width(), bounding_rect.height() / 2)
+            hit_zone = RectHitZone(QRectF(
+                QPointF(p1.x(), p1.y() - line_w / 2),
+                QSizeF(bounding_rect.width(), line_w),
+            ))
         elif orientation == Qt.Orientation.Vertical:
             line_h = min(pen.widthF(), bounding_rect.height())
             pen.setWidthF(line_h)
             p1 = QPointF(bounding_rect.width() / 2, 0)
             p2 = QPointF(bounding_rect.width() / 2, bounding_rect.height())
+
+            hit_zone = RectHitZone(QRectF(
+                QPointF(p1.x() - line_h / 2, p1.y()),
+                QSizeF(line_h, bounding_rect.height()),
+            ))
+
         else:
             raise NotImplementedError("Unknown orientation")
+
+        self._set_hit_zone(hit_zone)
 
         painter.setPen(pen)
         painter.drawLine(p1, p2)
@@ -95,27 +116,27 @@ class LineHMIWidget(BaseHMIWidget):
     def get_implementation_config_dict(self) -> Dict[str, Any]:
         return {
             'border': self._pen_config.get_state_dict(),
-            'direction': cast(Qt.Orientation, self._cmb_direction.currentData()).value
+            'orientation': cast(Qt.Orientation, self._cmb_orientation.currentData()).value
         }
 
     def apply_implementation_config_dict(self, d: Dict[str, Any]) -> bool:
         border_valid = False
-        direction_valid = False
+        orientation_valid = False
 
         if 'border' in d and isinstance(d['border'], dict):
             border_valid = self._pen_config.set_state_dict(cast(PenConfigStateDict, d['border']))
 
-        if 'direction' in d and isinstance(d['direction'], int):
-            index = self._cmb_direction.findData(Qt.Orientation(d['direction']))
+        if 'orientation' in d and isinstance(d['orientation'], int):
+            index = self._cmb_orientation.findData(Qt.Orientation(d['orientation']))
             if index >= 0:
-                self._cmb_direction.setCurrentIndex(index)
-                direction_valid = True
+                self._cmb_orientation.setCurrentIndex(index)
+                orientation_valid = True
 
         if not border_valid:
             self._logger.warning(f"Invalid border settings for HMI Widget: {self.get_display_name()}")
 
-        if not direction_valid:
-            self._logger.warning(f"Invalid direction for HMI Widget: {self.get_display_name()}")
+        if not orientation_valid:
+            self._logger.warning(f"Invalid orientation for HMI Widget: {self.get_display_name()}")
 
-        return direction_valid and border_valid
+        return orientation_valid and border_valid
 # endregion

--- a/scrutiny/gui/components/locals/hmi/hmi_workzone.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_workzone.py
@@ -111,7 +111,7 @@ class HMIWorkZone(QGraphicsView):
     """The rubber band when selecting multiple HMI widgets"""
     _rubberband_active: bool
     """A flag indicating if a rubber band is visible and being stretched"""
-    _allow_edit_widgets: bool
+    _edit_mode: bool
     """A flag allowing to move/resize HMI widgets """
     _mouse_edit_data: Optional[WidgetMouseEditData]
     """The state data when a mouse press is active. Contains move/resize specific data"""
@@ -140,7 +140,7 @@ class HMIWorkZone(QGraphicsView):
         self._rubberband.setParent(self)
         self._rubberband_active = False
         self._rubberband.setVisible(False)
-        self._allow_edit_widgets = False
+        self._edit_mode = False
         self._mouse_edit_data = None
         self._grid = HMIEditGrid(self)
         self._grid.set_size(self.viewport().size())
@@ -150,6 +150,8 @@ class HMIWorkZone(QGraphicsView):
         self._drop_placeholder.setZValue(10000)
         self.scene().addItem(self._grid)
         self.scene().addItem(self._drop_placeholder)
+
+        self.setMouseTracking(True)
 
     def destroy(self, destroyWindow: bool = False, destroySubWindows: bool = False) -> None:
         for item in list(self.scene().items()):
@@ -213,15 +215,12 @@ class HMIWorkZone(QGraphicsView):
         """Return the list of actually selected HMI widget"""
         return self._selected_widgets.copy()
 
-    def set_allow_edit_widgets(self, val: bool) -> None:
+    def set_edit_mode(self, val: bool) -> None:
         """Allow or disallow editing HMI widgets"""
-        self._allow_edit_widgets = val
+        self._edit_mode = val
 
-        if self._allow_edit_widgets:
-            self.setMouseTracking(True)
-        else:
+        if not self._edit_mode:
             self._mouse_edit_data = None
-            self.setMouseTracking(False)
 
     def _compute_rubber_band_rect(self, start: QPoint, end: QPoint) -> QRect:
         """Get the start and end point of a rubber band selection and return a QRect with dimension in the right orders"""
@@ -231,11 +230,14 @@ class HMIWorkZone(QGraphicsView):
         right = max(start.x(), end.x())
         return QRect(QPoint(left, top), QPoint(right, bottom))
 
-    def hmi_widget_at(self, pos: QPoint) -> Optional[BaseHMIWidget]:
+    def hmi_widget_at(self, pos: QPoint, perform_hit_test: bool = False) -> Optional[BaseHMIWidget]:
         """Tells what HMI widget is at a location. Returns the one on the top (highest z-value) if many"""
         for item in self.items(pos):
             if isinstance(item, BaseHMIWidget):
-                return item
+                if not perform_hit_test:
+                    return item
+                elif item.hit_test(item.mapFromScene(self.mapToScene(pos))):
+                    return item
         return None
 
     def resizeEvent(self, event: QResizeEvent) -> None:
@@ -255,7 +257,7 @@ class HMIWorkZone(QGraphicsView):
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
         event.accept()
         cursor = Qt.CursorShape.ArrowCursor
-        if self._allow_edit_widgets:
+        if self._edit_mode:
             scene_pos = self.mapToScene(event.pos())
             if self._rubberband_active:     # User is making a selection with a rubber band
                 assert self._mouse_down_start is not None
@@ -269,14 +271,18 @@ class HMIWorkZone(QGraphicsView):
                         cursor = self._view_mousemove_resize_widget(event)  # Handle resize action
                 else:   # Nothing is happening
                     # Check if we should display a resize cursor if use hover a resize handle
-                    item = self.hmi_widget_at(event.pos())
-                    if item is not None:
-                        local_pos = item.mapFromScene(scene_pos)
-                        for handle, rect in item.resize_handles_coordinates().items():
+                    hmi_widget = self.hmi_widget_at(event.pos(), perform_hit_test=False)
+                    if hmi_widget is not None:
+                        local_pos = hmi_widget.mapFromScene(scene_pos)
+                        for handle, rect in hmi_widget.resize_handles_coordinates().items():
                             if rect.contains(local_pos):
                                 cursor = RESIZE_CURSOR_MAP[handle]
                                 break
 
+        else:
+            hmi_widget = self.hmi_widget_at(event.pos(), perform_hit_test=True)
+            if hmi_widget is not None:
+                cursor = hmi_widget.mouse_move(hmi_widget.mapFromScene(self.mapToScene(event.pos())))
         self.setCursor(cursor)
 
     def _selection_changed_slot(self, widgets: List[BaseHMIWidget]) -> None:
@@ -389,19 +395,15 @@ class HMIWorkZone(QGraphicsView):
         return cursor
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
+        cursor = Qt.CursorShape.ArrowCursor
         event.accept()
         self._mouse_down_start = event.pos()
-        mouse_down_item = self.hmi_widget_at(event.pos())
-        self._mouse_down_widget = None
         must_propagate_left_button = False
-
-        if isinstance(mouse_down_item, BaseHMIWidget):
-            # Remember on what the user clicked. Ignore the Grid
-            self._mouse_down_widget = mouse_down_item
+        self._mouse_down_widget = self.hmi_widget_at(event.pos(), perform_hit_test=not self._edit_mode)
 
         if event.button() == Qt.MouseButton.LeftButton:
             self._mouse_edit_data = None
-            if self._allow_edit_widgets:
+            if self._edit_mode:
                 if self._mouse_down_widget is None:  # Clicked nothing (grid). Start a rubber band
                     self._rubberband_active = True
                 else:  # Clicked an HMI Widget
@@ -459,16 +461,15 @@ class HMIWorkZone(QGraphicsView):
         # Prevent propagation if we took the event.
         # Prevents control widget to react when moving
         if must_propagate_left_button and self._mouse_down_widget is not None:
-            self._mouse_down_widget.left_mouse_down(self._mouse_down_widget.mapFromScene(self.mapToScene(event.pos())))
+            cursor = self._mouse_down_widget.left_mouse_down(self._mouse_down_widget.mapFromScene(self.mapToScene(event.pos())))
+        self.setCursor(cursor)
 
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        cursor = Qt.CursorShape.ArrowCursor
         event.accept()
-        mouse_release_widget: Optional[QGraphicsItem] = None
         self._status_bar.set_resize_size(None)
         if self._mouse_down_start is not None:
-            mouse_release_widget = self.hmi_widget_at(event.pos())
-            if not isinstance(mouse_release_widget, BaseHMIWidget):  # Works for None and Grid
-                mouse_release_widget = None
+            mouse_release_widget = self.hmi_widget_at(event.pos(), perform_hit_test=not self._edit_mode)
 
             # Check if right-click
             if event.button() == Qt.MouseButton.RightButton:
@@ -477,7 +478,7 @@ class HMIWorkZone(QGraphicsView):
                     self._signals.right_click.emit(mouse_release_widget, event)
 
             elif event.button() == Qt.MouseButton.LeftButton:
-                if self._allow_edit_widgets:
+                if self._edit_mode:
                     if event.pos() == self._mouse_down_start:
                         self._rubberband_active = False
 
@@ -509,16 +510,16 @@ class HMIWorkZone(QGraphicsView):
 
                 elif self._mouse_down_widget is not None:
                     if mouse_release_widget is self._mouse_down_widget:
-                        self._mouse_down_widget.left_mouse_up(self._mouse_down_widget.mapFromScene(self.mapToScene(event.pos())))
+                        cursor = self._mouse_down_widget.left_mouse_up(self._mouse_down_widget.mapFromScene(self.mapToScene(event.pos())))
                     else:
-                        self._mouse_down_widget.left_mouse_up(None)
+                        cursor = self._mouse_down_widget.left_mouse_up(None)
 
         self._mouse_down_widget = None
         self._mouse_down_start = None
         self._rubberband.setVisible(False)
         self._rubberband_active = False
         self._mouse_edit_data = None
-        self.setCursor(Qt.CursorShape.ArrowCursor)
+        self.setCursor(cursor)
 
     def mouseDoubleClickEvent(self, event: QMouseEvent) -> None:
         # We don't handle double clicks.

--- a/test/gui/test_hmi_component.py
+++ b/test/gui/test_hmi_component.py
@@ -58,6 +58,9 @@ class DummyAppInterface(AbstractComponentAppInterface):
 class HMIComponentBaseTest(ScrutinyBaseGuiTest):
     def setUp(self):
         super().setUp()
+        self.paint_device = QImage(640, 480, QImage.Format.Format_RGB32)
+        self.paint_device.fill(Qt.GlobalColor.white)
+
         settings = ScrutinyQtGUI.Settings(
             debug_layout=False,
             auto_connect=False,
@@ -90,6 +93,17 @@ class HMIComponentBaseTest(ScrutinyBaseGuiTest):
     def tearDown(self):
         self.hmi_component.teardown()
         return super().tearDown()
+
+    def _render_scene(self):
+        scene = self.hmi_component.get_workzone().scene()
+        scene.invalidate()
+        painter = QPainter(self.paint_device)
+        self.hmi_component.get_workzone().render(
+            painter,
+            self.paint_device.rect(),
+            scene.sceneRect().toRect()
+        )
+        painter.end()
 
 
 class TestHMIWidgetSerialization(HMIComponentBaseTest):
@@ -191,6 +205,7 @@ class TestHMIWidgetSerialization(HMIComponentBaseTest):
         pen1.setColor(QColor("#123456"))
         pen1.setStyle(Qt.PenStyle.DashDotLine)
         line.set_border_pen(pen1)
+        line.set_orientation(Qt.Orientation.Vertical)
 
         state = self.hmi_component.get_state()
         self.hmi_component.delete_hmi_widget(line)
@@ -214,6 +229,7 @@ class TestHMIWidgetSerialization(HMIComponentBaseTest):
         self.assertEqual(pen1.widthF(), pen2.widthF())
         self.assertEqual(pen1.color(), pen2.color())
         self.assertEqual(pen1.style(), pen2.style())
+        self.assertEqual(new_line.get_orientation(), line.get_orientation())
 
     def test_serialize_text_label(self):
         text_label = TextLabelHMIWidget(self.app_interface)
@@ -993,7 +1009,7 @@ class TestWorkZone(HMIComponentBaseTest):
         self.assertEqual(right_click_list[0], circle)
         self.assertEqual(right_click_list[1], None)
 
-    def test_zvalue_manipualtion(self):
+    def test_zvalue_manipulation(self):
         workzone = self.hmi_component.get_workzone()
         circle1 = CircleHMIWidget(self.app_interface)
         circle2 = CircleHMIWidget(self.app_interface)
@@ -1064,6 +1080,84 @@ class TestWorkZone(HMIComponentBaseTest):
         self.assertEqual(self.app_interface.watchable_registry.node_watcher_count(sdk.WatchableType.Variable, '/var/aaa'), 0)
         self.hmi_component.visibilityChanged(True)
         self.assertEqual(self.app_interface.watchable_registry.node_watcher_count(sdk.WatchableType.Variable, '/var/aaa'), 1)
+
+    def test_button_press_check_hit_test(self):
+        DOWN = 0
+        UP = 1
+        MOVE = 2
+
+        event_history: List[Tuple[Type, int]] = []
+
+        class Circle2(CircleHMIWidget):
+            def left_mouse_down(self, pos: QPointF) -> Qt.CursorShape:
+                event_history.append((self.__class__, DOWN))
+                return super().left_mouse_down(pos)
+
+            def left_mouse_up(self, pos: Optional[QPointF]) -> Qt.CursorShape:
+                event_history.append((self.__class__, UP))
+                return super().left_mouse_up(pos)
+
+            def mouse_move(self, pos: QPointF) -> Qt.CursorShape:
+                event_history.append((self.__class__, MOVE))
+                return super().mouse_move(pos)
+
+        class Rectangle2(RectangleHMIWidget):
+            def left_mouse_down(self, pos: QPointF) -> Qt.CursorShape:
+                event_history.append((self.__class__, DOWN))
+                return super().left_mouse_down(pos)
+
+            def left_mouse_up(self, pos: Optional[QPointF]) -> Qt.CursorShape:
+                event_history.append((self.__class__, UP))
+                return super().left_mouse_up(pos)
+
+            def mouse_move(self, pos: QPointF) -> Qt.CursorShape:
+                event_history.append((self.__class__, MOVE))
+                return super().mouse_move(pos)
+
+        circle = Circle2(self.app_interface)
+        rectangle = Rectangle2(self.app_interface)
+
+        rectangle.set_size(QSize(128, 128))
+        circle.set_size(QSize(128, 128))
+        self.hmi_component.add_hmi_widget(rectangle, QPoint(50, 100))
+        self.hmi_component.add_hmi_widget(circle, QPoint(50, 100))
+        self.hmi_component.move_to_front(circle)
+
+        self._render_scene()
+
+        workzone = self.hmi_component.get_workzone()
+
+        p = QPointF(60, 110)
+        down_event = QMouseEvent(QEvent.Type.MouseButtonPress, p,
+                                 Qt.MouseButton.LeftButton, Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier
+                                 )
+        up_event = QMouseEvent(QEvent.Type.MouseButtonRelease, p,
+                               Qt.MouseButton.LeftButton, Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier
+                               )
+        move_event = QMouseEvent(QEvent.Type.MouseButtonPress, p,
+                                 Qt.MouseButton.LeftButton, Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier
+                                 )
+
+        # In edit mode, the widget never receives the events. The workzone keeps them
+        workzone.set_edit_mode(True)
+        workzone.mousePressEvent(down_event)
+        workzone.mouseReleaseEvent(up_event)
+        workzone.mouseMoveEvent(move_event)
+
+        self.assertEqual(len(event_history), 0)
+        self.assertEqual(len(workzone.selected_widgets()), 1)
+        self.assertIs(workzone.selected_widgets()[0], circle)
+
+        # In display mode, the events invoke the widget methods.
+        # Empty region is considered through the HitZone
+        workzone.set_edit_mode(False)
+        workzone.mousePressEvent(down_event)
+        workzone.mouseReleaseEvent(up_event)
+        workzone.mouseMoveEvent(move_event)
+        self.assertEqual(len(event_history), 3)
+        self.assertEqual(event_history[0], (Rectangle2, DOWN))
+        self.assertEqual(event_history[1], (Rectangle2, UP))
+        self.assertEqual(event_history[2], (Rectangle2, MOVE))
 
 
 class TestHMIComponent(HMIComponentBaseTest):
@@ -1141,22 +1235,6 @@ class TestHMIComponent(HMIComponentBaseTest):
 
 
 class TestHMIWidgets(HMIComponentBaseTest):
-
-    def setUp(self):
-        super().setUp()
-        self.paint_device = QImage(640, 480, QImage.Format.Format_RGB32)
-        self.paint_device.fill(Qt.GlobalColor.white)
-
-    def _render_scene(self):
-        scene = self.hmi_component.get_workzone().scene()
-        scene.invalidate()
-        painter = QPainter(self.paint_device)
-        self.hmi_component.get_workzone().render(
-            painter,
-            self.paint_device.rect(),
-            scene.sceneRect().toRect()
-        )
-        painter.end()
 
     def test_basic_shapes_draw(self):
         rectangle = RectangleHMIWidget(self.app_interface)
@@ -1343,3 +1421,123 @@ class TestHMIWidgets(HMIComponentBaseTest):
         self.assertEqual(len(write_history), 2)
         self.assertEqual(write_history[1].fqn, bool_fqn)
         self.assertEqual(write_history[1].value, False)
+
+    def test_radial_gauge_hit_zone(self):
+        gauge = RadialGaugeHMIWidget(self.app_interface)
+        gauge.set_size(QSize(128, 64))
+
+        self.hmi_component.add_hmi_widget(gauge, QPoint(64, 32))
+        gauge.update()
+        self._render_scene()
+
+        # Corners
+        self.assertFalse(gauge.hit_test(QPointF(0, 0)))
+        self.assertFalse(gauge.hit_test(QPointF(127, 127)))
+        self.assertFalse(gauge.hit_test(QPointF(127, 63)))
+        self.assertFalse(gauge.hit_test(QPointF(0, 63)))
+
+        # Just outside the perimeter
+        self.assertFalse(gauge.hit_test(QPointF(14, 11)))
+        self.assertFalse(gauge.hit_test(QPointF(114, 11)))
+        self.assertFalse(gauge.hit_test(QPointF(114, 53)))
+        self.assertFalse(gauge.hit_test(QPointF(14, 53)))
+
+        # Center
+        self.assertTrue(gauge.hit_test(QPointF(64, 32)))
+
+        # Just inside the perimeter
+        self.assertTrue(gauge.hit_test(QPointF(14, 13)))
+        self.assertTrue(gauge.hit_test(QPointF(114, 13)))
+        self.assertTrue(gauge.hit_test(QPointF(14, 51)))
+        self.assertTrue(gauge.hit_test(QPointF(114, 51)))
+
+    def test_color_indicator_hit_zone(self):
+        indicator = ColorIndicatorHMIWidget(self.app_interface)
+        indicator.set_size(QSize(128, 64))
+
+        self.hmi_component.add_hmi_widget(indicator, QPoint(64, 32))
+        indicator.update()
+        self._render_scene()
+
+        # Corners
+        self.assertFalse(indicator.hit_test(QPointF(0, 0)))
+        self.assertFalse(indicator.hit_test(QPointF(127, 127)))
+        self.assertFalse(indicator.hit_test(QPointF(127, 63)))
+        self.assertFalse(indicator.hit_test(QPointF(0, 63)))
+
+        # Just outside the perimeter
+        self.assertFalse(indicator.hit_test(QPointF(14, 11)))
+        self.assertFalse(indicator.hit_test(QPointF(114, 11)))
+        self.assertFalse(indicator.hit_test(QPointF(114, 53)))
+        self.assertFalse(indicator.hit_test(QPointF(14, 53)))
+
+        # Center
+        self.assertTrue(indicator.hit_test(QPointF(64, 32)))
+
+        # Just inside the perimeter
+        self.assertTrue(indicator.hit_test(QPointF(14, 13)))
+        self.assertTrue(indicator.hit_test(QPointF(114, 13)))
+        self.assertTrue(indicator.hit_test(QPointF(14, 51)))
+        self.assertTrue(indicator.hit_test(QPointF(114, 51)))
+
+    def test_circle_hit_zone(self):
+        circle = CircleHMIWidget(self.app_interface)
+        circle.set_size(QSize(128, 64))
+
+        self.hmi_component.add_hmi_widget(circle, QPoint(64, 32))
+        circle.update()
+        self._render_scene()
+
+        # Corners
+        self.assertFalse(circle.hit_test(QPointF(0, 0)))
+        self.assertFalse(circle.hit_test(QPointF(127, 127)))
+        self.assertFalse(circle.hit_test(QPointF(127, 63)))
+        self.assertFalse(circle.hit_test(QPointF(0, 63)))
+
+        # Just outside the perimeter
+        self.assertFalse(circle.hit_test(QPointF(14, 11)))
+        self.assertFalse(circle.hit_test(QPointF(114, 11)))
+        self.assertFalse(circle.hit_test(QPointF(114, 53)))
+        self.assertFalse(circle.hit_test(QPointF(14, 53)))
+
+        # Center
+        self.assertTrue(circle.hit_test(QPointF(64, 32)))
+
+        # Just inside the perimeter
+        self.assertTrue(circle.hit_test(QPointF(14, 13)))
+        self.assertTrue(circle.hit_test(QPointF(114, 13)))
+        self.assertTrue(circle.hit_test(QPointF(14, 51)))
+        self.assertTrue(circle.hit_test(QPointF(114, 51)))
+
+    def test_line_hit_zone(self):
+        line = LineHMIWidget(self.app_interface)
+        line.set_size(QSize(128, 64))
+        pen = QPen()
+        pen.setWidthF(10)
+        line.set_border_pen(pen)
+        line.set_orientation(Qt.Orientation.Horizontal)
+
+        self.hmi_component.add_hmi_widget(line, QPoint(64, 32))
+        line.update()
+        self._render_scene()
+
+        self.assertFalse(line.hit_test(QPointF(0, 26)))
+        self.assertTrue(line.hit_test(QPointF(0, 27)))
+        self.assertTrue(line.hit_test(QPointF(0, 37)))
+        self.assertFalse(line.hit_test(QPointF(0, 38)))
+        self.assertFalse(line.hit_test(QPointF(127, 26)))
+        self.assertTrue(line.hit_test(QPointF(127, 27)))
+        self.assertTrue(line.hit_test(QPointF(127, 37)))
+        self.assertFalse(line.hit_test(QPointF(127, 38)))
+
+        line.set_orientation(Qt.Orientation.Vertical)
+        line.update()
+        self._render_scene()
+        self.assertFalse(line.hit_test(QPointF(58, 0)))
+        self.assertTrue(line.hit_test(QPointF(59, 0)))
+        self.assertTrue(line.hit_test(QPointF(69, 0)))
+        self.assertFalse(line.hit_test(QPointF(70, 0)))
+        self.assertFalse(line.hit_test(QPointF(58, 63)))
+        self.assertTrue(line.hit_test(QPointF(59, 63)))
+        self.assertTrue(line.hit_test(QPointF(69, 63)))
+        self.assertFalse(line.hit_test(QPointF(70, 63)))


### PR DESCRIPTION
- Each HMI widget can define the zone they occupy so clicking an empty zone can be forwarded to the HMI widget behind
- Mouse move is forwarded to the HMI widget in display mode.
- left_mouse_down, left_mouse_up and mouse_move now required to return the CursorShape
- Added more tests