### PR TITLE
WatchableLineEdit shows availabilities

### DIFF
--- a/scrutiny/gui/components/locals/embedded_graph/embedded_graph_component.py
+++ b/scrutiny/gui/components/locals/embedded_graph/embedded_graph_component.py
@@ -642,6 +642,7 @@ class EmbeddedGraphComponent(ScrutinyGUIBaseLocalComponent):
                 self._chartview.chart().set_grid_config(grid_config)
 
         self._signal_tree.update_all_availabilities()
+        self._graph_config_widget.update_watchable_availabilities()
 
         if log_and_suppress_exceptions.exception_logged:
             fully_valid = False
@@ -724,6 +725,7 @@ class EmbeddedGraphComponent(ScrutinyGUIBaseLocalComponent):
         """Called when the server manager has finished making a change to the registry"""
         if not self._state.has_content:  # We are not inspecting data.
             self._signal_tree.update_all_availabilities()
+        self._graph_config_widget.update_watchable_availabilities()
 
     def _datalogging_state_changed_slot(self) -> None:
         """When the server tells us that the datalogger has changed state"""

--- a/scrutiny/gui/components/locals/embedded_graph/graph_config_widget.py
+++ b/scrutiny/gui/components/locals/embedded_graph/graph_config_widget.py
@@ -647,6 +647,15 @@ class GraphConfigWidget(QWidget):
 
         self._txt_acquisition_name.setText(self.AUTONAME_PREFIX + str(num + 1))
 
+    def update_watchable_availabilities(self) -> None:
+        txtw_operands = [self._txtw_trigger_operand1, self._txtw_trigger_operand2, self._txtw_trigger_operand3]
+        for txtw_operand in txtw_operands:
+            if txtw_operand.is_watchable_mode():
+                watchable = txtw_operand.get_watchable()
+                assert watchable is not None
+                exist = self._watchable_registry.is_watchable_fqn(watchable.fqn)
+                txtw_operand.set_watchable_available(exist)
+
     def get_txt_acquisition_name(self) -> QLineEdit:
         return self._txt_acquisition_name
 

--- a/scrutiny/gui/components/locals/hmi/hmi_widgets/base_hmi_widget.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_widgets/base_hmi_widget.py
@@ -664,8 +664,9 @@ class BaseHMIWidget(QGraphicsItem):
         """Try to subscribe to the WatchableRegistry (and the server)"""
         try:
             self._app.watchable_registry.watch_fqn(vslot.watcher_id, fqn, self.HMI_COMPONENT_UPDATE_RATE)
+            vslot.watchable_line_edit.set_watchable_available(True)
         except WatchableRegistryNodeNotFoundError:
-            pass
+            vslot.watchable_line_edit.set_watchable_available(False)
 
     def _unwatch_vslot(self, vslot: ValueSlot, fqn: str) -> None:
         """Unsubscribe the watchable of a value slot"""

--- a/scrutiny/gui/widgets/watchable_line_edit.py
+++ b/scrutiny/gui/widgets/watchable_line_edit.py
@@ -124,7 +124,7 @@ class WatchableLineEdit(QLineEdit):
         if emit_drop_fqn is not None:
             self._signals.watchable_dropped.emit(emit_drop_fqn)
 
-    def set_watchable_mode(self, watchable_type: WatchableType, path: str, name: str) -> None:
+    def set_watchable_mode(self, watchable_type: WatchableType, path: str, name: str, available: bool = True) -> None:
         """Sets this widget in watchable mode. in this mode, it display the watchable name with an icon and text edition
         is not possible. Only the clear button can alter it."""
         for action in list(self.actions()):  # Remove any previous left icon
@@ -138,7 +138,19 @@ class WatchableLineEdit(QLineEdit):
         self._loaded_watchable = WatchableFQNAndName(
             fqn=WatchableRegistry.FQN.make(watchable_type, path),
             name=name)
+        self.set_watchable_available(available)
         self._update_cursor()
+
+    def set_watchable_available(self, available: bool) -> None:
+        if not self.is_watchable_mode():
+            raise ValueError("Cannot call set_watchable_available when in text mode")
+
+        self._set_style_available(available)
+
+    def _set_style_available(self, available: bool) -> None:
+        font = self.font()
+        font.setStrikeOut(not available)
+        self.setFont(font)
 
     def _adjust_watchable_mode_margins(self) -> None:
         margins = self.textMargins()
@@ -178,6 +190,7 @@ class WatchableLineEdit(QLineEdit):
 
             if watchable is not None:
                 self._signals.watchable_cleared.emit(watchable.fqn)
+        self._set_style_available(True)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         if self._mode == self.Mode.WATCHABLE:

--- a/test/gui/manual/manual_test_watchable_line_edit.py
+++ b/test/gui/manual/manual_test_watchable_line_edit.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from manual_test_base import make_manual_test_app
 app = make_manual_test_app()
 
-from PySide6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QCheckBox, QLabel, QHBoxLayout
+from PySide6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QCheckBox, QLabel, QHBoxLayout, QPushButton
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QDoubleValidator
 from scrutiny.gui.widgets.watchable_line_edit import WatchableLineEdit
@@ -84,6 +84,20 @@ def state_changed(state: Qt.CheckState):
 chk_text_mode.checkStateChanged.connect(state_changed)
 chk_text_mode.setCheckState(Qt.CheckState.Checked)
 
+btn_set_available = QPushButton("Set Available")
+btn_set_unavailable = QPushButton("Set Unavailable")
+
+
+def set_available(val: bool):
+    if line_edit.is_watchable_mode():
+        line_edit.set_watchable_available(val)
+    if line_edit_double_validator.is_watchable_mode():
+        line_edit_double_validator.set_watchable_available(val)
+
+
+btn_set_available.clicked.connect(lambda _: set_available(True))
+btn_set_unavailable.clicked.connect(lambda _: set_available(False))
+
 widget_lineedit = QWidget()
 layout1 = QHBoxLayout(widget_lineedit)
 layout1.addWidget(QLabel("No Validator"))
@@ -94,9 +108,15 @@ layout2 = QHBoxLayout(widget_lineedit_double_validator)
 layout2.addWidget(QLabel("Validator"))
 layout2.addWidget(line_edit_double_validator)
 
+available_widget = QWidget()
+available_widget_layout = QHBoxLayout(available_widget)
+available_widget_layout.addWidget(btn_set_available)
+available_widget_layout.addWidget(btn_set_unavailable)
+
 layout.addWidget(widget_lineedit)
 layout.addWidget(widget_lineedit_double_validator)
 layout.addWidget(chk_text_mode)
+layout.addWidget(available_widget)
 layout.addWidget(varlist)
 
 window.show()


### PR DESCRIPTION
- WatchableLineEdit can visually indicates if a watchable is available or not by using striked-out font. Used in EmbeddedGraph trigger and HMI input values