### PR TITLE
HMI - Fix state reload issues

### DIFF
--- a/scrutiny/gui/components/base_component.py
+++ b/scrutiny/gui/components/base_component.py
@@ -26,6 +26,7 @@ class ScrutinyGUIBaseComponent(QWidget):
     main_window: "MainWindow"
     app: AbstractComponentAppInterface
     logger: logging.Logger
+    _pending_state_reload:Optional[Dict[Any, Any]]
 
     def __init__(self,
                  main_window: "MainWindow",
@@ -35,6 +36,7 @@ class ScrutinyGUIBaseComponent(QWidget):
         self.instance_name = instance_name
         self.main_window = main_window
         self.app = app_interface
+        self._pending_state_reload = None
         self.logger = logging.getLogger(self.__class__.__name__)
         super().__init__()
 
@@ -72,6 +74,23 @@ class ScrutinyGUIBaseComponent(QWidget):
         if not hasattr(cls, '_TYPE_ID'):
             raise RuntimeError(f"Class {cls.__name__} require the _TYPE_ID to be set")
         return cast(str, getattr(cls, '_TYPE_ID'))
+
+    def attach_pending_state_to_reload(self, state:Dict[Any, Any]):
+        self._pending_state_reload = state
+
+    def has_pending_state_to_reload(self) -> bool:
+        return self._pending_state_reload is not None
+
+    def reload_pending_state(self) -> bool:
+        if self._pending_state_reload is None:
+            return False
+        result = False
+        try:
+            result = self.load_state(self._pending_state_reload)
+        finally:
+            self._pending_state_reload = None
+
+        return result
 
     @abstractmethod
     def setup(self) -> None:

--- a/scrutiny/gui/components/base_component.py
+++ b/scrutiny/gui/components/base_component.py
@@ -26,7 +26,7 @@ class ScrutinyGUIBaseComponent(QWidget):
     main_window: "MainWindow"
     app: AbstractComponentAppInterface
     logger: logging.Logger
-    _pending_state_reload:Optional[Dict[Any, Any]]
+    _pending_state_reload: Optional[Dict[Any, Any]]
 
     def __init__(self,
                  main_window: "MainWindow",
@@ -75,7 +75,7 @@ class ScrutinyGUIBaseComponent(QWidget):
             raise RuntimeError(f"Class {cls.__name__} require the _TYPE_ID to be set")
         return cast(str, getattr(cls, '_TYPE_ID'))
 
-    def attach_pending_state_to_reload(self, state:Dict[Any, Any]):
+    def attach_pending_state_to_reload(self, state: Dict[Any, Any]) -> None:
         self._pending_state_reload = state
 
     def has_pending_state_to_reload(self) -> bool:

--- a/scrutiny/gui/components/locals/hmi/hmi_component.py
+++ b/scrutiny/gui/components/locals/hmi/hmi_component.py
@@ -272,6 +272,7 @@ class HMIComponent(ScrutinyGUIBaseLocalComponent):
                 fully_loaded_ok = False
 
         self._reassign_packed_zvalues()
+        self._resubscribe_all_hmi_widgets()
         self.set_mode(HMIInteractionMode.Display)
         return fully_loaded_ok
 

--- a/scrutiny/gui/dashboard/dashboard.py
+++ b/scrutiny/gui/dashboard/dashboard.py
@@ -628,7 +628,21 @@ class Dashboard(QWidget):
         def ready_if_not_deleted() -> None:
             # If the component is created but unused (deleted at func exit)
             if shiboken6.isValid(widget):
+                self._logger.debug(f"Invoking ready() on {widget.instance_name}")
                 widget.ready()
+
+                # If the widget has been created by reloading a dashboard (.scdb)
+                # There might be a pending state waiting to be reloaded.
+                # The state may be attached after creation. So we make the check in the ready func.
+                if widget.has_pending_state_to_reload():
+                    component_name = f"\"{dock_widget.tabWidget().text()}\" (type={component_class.__name__})"
+                    self._logger.debug(f"Reloading state of {widget.instance_name}")
+
+                    with tools.LogException(self._logger, Exception, f"Failed to reload the state of component {component_name}"):
+                        fully_valid = widget.reload_pending_state()
+                        if not fully_valid:
+                            self._logger.warning(f"State of component {component_name} was not fully reloaded. Some content was not valid")
+
         self._component_instances[name] = widget
 
         invoke_later(ready_if_not_deleted)
@@ -661,13 +675,7 @@ class Dashboard(QWidget):
             component = cast(Optional[ScrutinyGUIBaseComponent], component_dock_widget.widget())
             assert component is not None
 
-            component_name = f"\"{s_component.title}\" (type={component_class.__name__})"
-            try:
-                fully_valid = component.load_state(s_component.state)
-                if not fully_valid:
-                    self._logger.warning(f"State of component {component_name} was not fully reloaded. Some content was not valid")
-            except Exception as e:
-                tools.log_exception(self._logger, e, f"Failed to reload the state of component {component_name}")
+            component.attach_pending_state_to_reload(s_component.state)
 
         return component_dock_widget
 

--- a/test/gui/test_dashboard.py
+++ b/test/gui/test_dashboard.py
@@ -33,6 +33,7 @@ class StubbedComponent(ScrutinyGUIBaseComponent):
     ready_called: bool
     teardown_called: bool
     state: Dict[Any, Any]
+    call_history:List[str]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -40,21 +41,28 @@ class StubbedComponent(ScrutinyGUIBaseComponent):
         self.ready_called = False
         self.teardown_called = False
         self.state = {}
+        self.call_history = []
 
     def setup(self) -> None:
+        self.call_history.append("setup")
         self.setup_called = True
 
     def ready(self) -> None:
+        self.call_history.append("ready")
         self.ready_called = True
 
     def teardown(self) -> None:
+        self.call_history.append("teardown")
         self.teardown_called = True
 
     def get_state(self) -> Dict[Any, Any]:
+        self.call_history.append("get_state")
         return self.state
 
     def load_state(self, state: Dict[Any, Any]) -> bool:
+        self.call_history.append("load_state")
         self.state = state
+        return True
 
 
 class StubbedGlobalComponent(StubbedComponent, ScrutinyGUIBaseGlobalComponent):
@@ -268,6 +276,9 @@ class TestDashboard(ScrutinyBaseGuiTest):
             dashboard.save(file)
             new_dashboard.open(file, exceptions=True)
 
+        # Load state is delayed to happen after UI stabilize
+        self.process_events()   # Invoke Ready, load_state
+
         # New dashboard is reloaded from file. Check that it matches the original one.
         self.assertEqual(len(new_dashboard.dock_manager().dockWidgetsMap()), len(all_dock_widgets))
         containers = new_dashboard.dock_manager().dockContainers()
@@ -407,6 +418,25 @@ class TestDashboard(ScrutinyBaseGuiTest):
         self.assertFalse(dock_widget2.isFloating())
         self.assertFalse(dock_widget2.dockAreaWidget().isAutoHide())
         self.assertTrue(dock_widget2.isTabbed())    # Share tab with local component
+
+    def test_call_order(self):
+        dashboard1 = Dashboard(self.main_window)
+        dashboard2 = Dashboard(self.main_window)
+        dashboard1.add_local_component(StubbedLocalComponent)
+
+        self.assertEqual(len(dashboard2.dock_manager().dockWidgetsMap()), 0)
+        with tempfile.TemporaryDirectory() as d:
+            file = Path(os.path.join(d, 'test_dashboard'))
+            dashboard1.save(file)
+            dashboard2.open(file, exceptions=True)
+
+        items = list(dashboard2.dock_manager().dockWidgetsMap().items())
+        self.assertEqual(len(items), 1)
+        key, dock_widget = items[0]
+        component = dock_widget.widget()
+        assert isinstance(component, StubbedLocalComponent)
+        self.process_events()
+        self.assertEqual(component.call_history, ['setup', 'ready', 'load_state'])
 
     def test_ads_bug_739(self):
         QtAds.CDockManager.setAutoHideConfigFlags(QtAds.CDockManager.DefaultAutoHideConfig)

--- a/test/gui/test_dashboard.py
+++ b/test/gui/test_dashboard.py
@@ -33,7 +33,7 @@ class StubbedComponent(ScrutinyGUIBaseComponent):
     ready_called: bool
     teardown_called: bool
     state: Dict[Any, Any]
-    call_history:List[str]
+    call_history: List[str]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
- HMI: resubscribe watchable after state reload
- Dashboard: Load state after call to ready (and geometry computation).
  - Previous order :  setup(), load_state(), geometry computation, ready() 
  - New order : setup(), geometry computation, ready(), load_state()