### PR TITLE
Refactor ServerManager to use a threadpool for client requests

### DIFF
--- a/.codebanner.json
+++ b/.codebanner.json
@@ -474,9 +474,6 @@
         "scrutiny/gui/core/watchable_registry.py": {
             "docstring": "A storage object that keeps a local copy of all the watchable (Variable/Alias/RPV) available on the server. \nLots of overlapping feature with the server datastore, with few fundamentals differences."
         },
-        "scrutiny/gui/core/server_manager.py": {
-            "docstring": "Object that handles the communication with the server and inform the rest of the GUI about what's happening on the other side of the socket. Based on the SDK ScrutinyClient"
-        },
         "scrutiny/gui/components/base_component.py": {
             "docstring": "A base class for a component that can be added to the GUI (globally or on the dashboard)"
         },
@@ -1118,6 +1115,15 @@
         },
         "scrutiny/gui/widgets/tooltip_form_layout.py": {
             "docstring": "An extension of the QFormLayout that can easily add tooltips on the label"
+        },
+        "scrutiny/gui/core/server_manager/qt_buffered_listener.py": {
+            "docstring": "A custom sdk.Listener meant to broadcast value upadtes the the QT GUI."
+        },
+        "scrutiny/gui/core/server_manager/server_manager.py": {
+            "docstring": "Object that handles the communication with the server and inform the rest of the GUI about what's happening on the other side of the socket. Based on the SDK ScrutinyClient"
+        },
+        "scrutiny/gui/core/server_manager/client_task_reactor.py": {
+            "docstring": "A reactor that can pipeline blocking requests to the server using the synchronous SDK. Uses a threadpool"
         }
     },
     "authors": {}

--- a/scrutiny/gui/component_app_interface.py
+++ b/scrutiny/gui/component_app_interface.py
@@ -9,7 +9,7 @@
 import abc
 
 from scrutiny.gui.core.watchable_registry import WatchableRegistry
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 
 
 class AbstractComponentAppInterface(abc.ABC):

--- a/scrutiny/gui/core/server_manager/client_task_reactor.py
+++ b/scrutiny/gui/core/server_manager/client_task_reactor.py
@@ -11,6 +11,7 @@ import queue
 import threading
 import logging
 import functools
+from dataclasses import dataclass
 
 from scrutiny.sdk.client import ScrutinyClient
 from scrutiny.tools.typing import *
@@ -18,22 +19,38 @@ from scrutiny.gui.core.threads import QT_THREAD_NAME
 from scrutiny.tools.thread_enforcer import enforce_thread
 from scrutiny.gui.tools.invoker import invoke_in_qt_thread
 
-ReactorTask:TypeAlias = Callable[[ScrutinyClient], Any]
-UICallbackFunc:TypeAlias = Callable[[Any, Optional[Exception]], None]
+ReactorTask: TypeAlias = Callable[[ScrutinyClient], Any]
+UICallbackFunc: TypeAlias = Callable[[Any, Optional[Exception]], None]
+
+
+@dataclass(slots=True)
+class TaskQueueEntry:
+    task_id: int
+    task: ReactorTask
+    ui_callback: UICallbackFunc
+
 
 class StoppedException(Exception):
     pass
 
-class ClientTaskReactor:
-    _client:ScrutinyClient
-    _threads:List[threading.Thread]
-    _exit_event:threading.Event
-    _started_event:threading.Event
-    _logger:logging.Logger
-    _task_queue:"queue.Queue[Optional[Tuple[int, ReactorTask, UICallbackFunc]]]"
-    _next_task_id:int
 
-    def __init__(self, client:ScrutinyClient, nb_thread:int, queue_max_size:int ) -> None:
+class ClientTaskReactor:
+    _client: ScrutinyClient
+    """Reference to a ScrutinyClient that the user can use in its task"""
+    _threads: List[threading.Thread]
+    """The thread pool"""
+    _exit_event: threading.Event
+    """Stop event for the active session (time span between start and stop)"""
+    _started_event: threading.Event
+    """Start event for the active session (time span between start and stop). No task is taken by the thread pool until this is fired"""
+    _task_queue: "queue.Queue[Optional[TaskQueueEntry]]"
+    """The task queue filled by the different component and read by the thread pool"""
+    _next_task_id: int
+    """A simple numerical ID to make sens eof the logs"""
+    _logger: logging.Logger
+    """The logger"""
+
+    def __init__(self, client: ScrutinyClient, nb_thread: int, queue_max_size: int) -> None:
         self._client = client
         self._nb_thread = nb_thread
         self._exit_event = threading.Event()
@@ -43,19 +60,22 @@ class ClientTaskReactor:
         self._next_task_id = 0
 
     @enforce_thread(QT_THREAD_NAME)
-    def put_task(self, task:ReactorTask, ui_callback:UICallbackFunc) -> None:
+    def put_task(self, task: ReactorTask, ui_callback: UICallbackFunc) -> None:
+        """Enqueue a task for the thread pool to execute"""
         task_id = self._next_task_id
         self._next_task_id += 1
         if self._logger.isEnabledFor(logging.DEBUG):
             self._logger.debug(f"Enqueuing task #{task_id}")
         try:
-            self._task_queue.put_nowait((task_id, task, ui_callback))
+            entry = TaskQueueEntry(task_id, task, ui_callback)
+            self._task_queue.put_nowait(entry)
         except queue.Full as e:
             self._logger.error("Task queue is full")
             ui_callback(None, e)
 
     @enforce_thread(QT_THREAD_NAME)
     def start(self) -> None:
+        """Start the threads"""
         self._logger.debug("Starting")
         if self._started_event.is_set():
             raise RuntimeError("Already started")
@@ -69,7 +89,7 @@ class ClientTaskReactor:
 
         self._threads = []
         for i in range(self._nb_thread):
-            thread = threading.Thread(target = self._thread_task, daemon=True)
+            thread = threading.Thread(target=self._thread_task, daemon=True)
             self._threads.append(thread)
 
         for thread in self._threads:
@@ -79,6 +99,7 @@ class ClientTaskReactor:
 
     @enforce_thread(QT_THREAD_NAME)
     def stop(self) -> None:
+        """Request all threads to exit. This method does not wait on thread to exit."""
         self._logger.debug("Stopping")
         # By setting this, we guarantee that each thread will not take on new tasks.
         # Only finish the one started.
@@ -89,13 +110,12 @@ class ClientTaskReactor:
         # Deplete the queue of any remaining task so we can inform the QT event loop of their non-completion.
         try:
             while not self._task_queue.empty():
-                func_pair = self._task_queue.get_nowait()
-                if func_pair is None:
+                entry = self._task_queue.get_nowait()
+                if entry is None:
                     continue
-                task_id, task, completion_callback = func_pair
                 if self._logger.isEnabledFor(logging.DEBUG):
-                    self._logger.debug(f"Cancelling task #{task_id}")
-                completion_callback(None, StoppedException("Reactor stopped"))
+                    self._logger.debug(f"Cancelling task #{entry.task_id}")
+                entry.ui_callback(None, StoppedException("Reactor stopped"))
         except queue.Empty:
             pass
 
@@ -109,6 +129,7 @@ class ClientTaskReactor:
         self._logger.debug("Stopped")
 
     def _thread_task(self) -> None:
+        """The function run by every thread"""
         started_event = self._started_event
         exit_event = self._exit_event
         started_event.wait(10)
@@ -118,21 +139,20 @@ class ClientTaskReactor:
             return
 
         while not exit_event.is_set():
-            func_pair = self._task_queue.get()
-            if func_pair is None:
+            entry = self._task_queue.get()
+            if entry is None:
                 continue
 
-            task_id, task, ui_callback = func_pair
-            result:Any = None
-            error:Optional[Exception] = None
+            result: Any = None
+            error: Optional[Exception] = None
             try:
                 if self._logger.isEnabledFor(logging.DEBUG):
-                    self._logger.debug(f"Executing task #{task_id}")
-                result = task(self._client)
+                    self._logger.debug(f"Executing task #{entry.task_id}")
+                result = entry.task(self._client)
                 if self._logger.isEnabledFor(logging.DEBUG):
-                    self._logger.debug(f"Task #{task_id} executed")
+                    self._logger.debug(f"Task #{entry.task_id} executed")
             except Exception as e:
-                self._logger.debug(f"Task #{task_id} failed")
+                self._logger.debug(f"Task #{entry.task_id} failed")
                 error = e
 
-            invoke_in_qt_thread(functools.partial(ui_callback, result, error))
+            invoke_in_qt_thread(functools.partial(entry.ui_callback, result, error)) # Non blocking

--- a/scrutiny/gui/core/server_manager/client_task_reactor.py
+++ b/scrutiny/gui/core/server_manager/client_task_reactor.py
@@ -50,8 +50,9 @@ class ClientTaskReactor:
             self._logger.debug(f"Enqueuing task #{task_id}")
         try:
             self._task_queue.put_nowait((task_id, task, ui_callback))
-        except queue.Full:
-            self._logger.critical("Task queue is full")
+        except queue.Full as e:
+            self._logger.error("Task queue is full")
+            ui_callback(None, e)
 
     @enforce_thread(QT_THREAD_NAME)
     def start(self) -> None:

--- a/scrutiny/gui/core/server_manager/client_task_reactor.py
+++ b/scrutiny/gui/core/server_manager/client_task_reactor.py
@@ -1,0 +1,116 @@
+
+import queue
+import threading
+import logging
+import functools
+
+from PySide6.QtCore import QObject, Signal
+from scrutiny.sdk.client import ScrutinyClient
+from scrutiny.tools.typing import *
+from scrutiny.gui.core.threads import QT_THREAD_NAME
+from scrutiny.tools.thread_enforcer import enforce_thread
+from scrutiny.gui.tools.invoker import invoke_in_qt_thread
+
+ReactorTask:TypeAlias = Callable[[ScrutinyClient], Any]
+UICallbackFunc:TypeAlias = Callable[[Any, Optional[Exception]], None]
+
+class StoppedException(Exception):
+    pass
+
+class ClientTaskReactor:
+    _client:ScrutinyClient
+    _threads:List[threading.Thread]
+    _exit_event:threading.Event
+    _started_event:threading.Event
+    _logger:logging.Logger
+    _task_queue:"queue.Queue[Optional[Tuple[ReactorTask, UICallbackFunc]]]"
+
+    def __init__(self, client:ScrutinyClient, nb_thread:int, queue_max_size:int ) -> None:
+        self._client = client
+        self._nb_thread = nb_thread
+        self._exit_event = threading.Event()
+        self._started_event = threading.Event()
+        self._logger = logging.Logger(self.__class__.__name__)
+        self._task_queue = queue.Queue(queue_max_size)
+
+    def put_task(self, task:ReactorTask, ui_callback:UICallbackFunc) -> None:
+        try:
+            self._task_queue.put_nowait((task, ui_callback))
+        except queue.Full:
+            self._logger.critical("Task queue is full")
+
+    @enforce_thread(QT_THREAD_NAME)
+    def start(self) -> None:
+        self._logger.debug("Starting")
+        if self._started_event.is_set():
+            raise RuntimeError("Already started")
+        # Create new events. In case the threads refuses to exit, we want them to check
+        # their own expired event.
+        self._exit_event = threading.Event()
+        self._started_event = threading.Event()
+
+        self._exit_event.clear()
+        self._started_event.clear()
+
+        self._threads = []
+        for i in range(self._nb_thread):
+            thread = threading.Thread(target = self._thread_task, daemon=True)
+            self._threads.append(thread)
+
+        for thread in self._threads:
+            thread.start()
+        self._started_event.set()
+        self._logger.debug("Started")
+
+    @enforce_thread(QT_THREAD_NAME)
+    def stop(self) -> None:
+        self._logger.debug("Stopping")
+        # By setting this, we guarantee that each thread will not take on new tasks.
+        # Only finish the one started.
+        # We expect the task to depend on the socket that should be closed at the same time as stopping this reactor
+        self._exit_event.set()
+        self._started_event.clear()
+
+        # Deplete the queue of any remaining task so we can inform the QT event loop of their non-completion.
+        try:
+            while not self._task_queue.empty():
+                func_pair = self._task_queue.get_nowait()
+                if func_pair is None:
+                    continue
+                task, completion_callback = func_pair
+                completion_callback(None, StoppedException("Reactor stopped"))
+        except queue.Empty:
+            pass
+
+        # Wake up all sleeping threads
+        # Works because
+        for i in range(self._nb_thread):
+            self._task_queue.put_nowait(None)
+
+        # Let the threads die by themselves. No need to join()
+        self._threads = []
+        self._logger.debug("Stopped")
+
+    def _thread_task(self) -> None:
+        started_event = self._started_event
+        exit_event = self._exit_event
+        started_event.wait(10)
+
+        if not started_event.is_set():
+            self._logger.critical("Failed to start")
+            return
+
+        while not exit_event.is_set():
+            func_pair = self._task_queue.get()
+            if func_pair is None:
+                continue
+
+            task, ui_callback = func_pair
+            result:Any = None
+            error:Optional[Exception] = None
+            try:
+                result = task(self._client)
+            except Exception as e:
+                error = e
+
+            invoke_in_qt_thread(functools.partial(ui_callback, result, error))

--- a/scrutiny/gui/core/server_manager/client_task_reactor.py
+++ b/scrutiny/gui/core/server_manager/client_task_reactor.py
@@ -4,7 +4,6 @@ import threading
 import logging
 import functools
 
-from PySide6.QtCore import QObject, Signal
 from scrutiny.sdk.client import ScrutinyClient
 from scrutiny.tools.typing import *
 from scrutiny.gui.core.threads import QT_THREAD_NAME
@@ -23,19 +22,26 @@ class ClientTaskReactor:
     _exit_event:threading.Event
     _started_event:threading.Event
     _logger:logging.Logger
-    _task_queue:"queue.Queue[Optional[Tuple[ReactorTask, UICallbackFunc]]]"
+    _task_queue:"queue.Queue[Optional[Tuple[int, ReactorTask, UICallbackFunc]]]"
+    _next_task_id:int
 
     def __init__(self, client:ScrutinyClient, nb_thread:int, queue_max_size:int ) -> None:
         self._client = client
         self._nb_thread = nb_thread
         self._exit_event = threading.Event()
         self._started_event = threading.Event()
-        self._logger = logging.Logger(self.__class__.__name__)
+        self._logger = logging.getLogger(self.__class__.__name__)
         self._task_queue = queue.Queue(queue_max_size)
+        self._next_task_id = 0
 
+    @enforce_thread(QT_THREAD_NAME)
     def put_task(self, task:ReactorTask, ui_callback:UICallbackFunc) -> None:
+        task_id = self._next_task_id
+        self._next_task_id += 1
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug(f"Enqueuing task #{task_id}")
         try:
-            self._task_queue.put_nowait((task, ui_callback))
+            self._task_queue.put_nowait((task_id, task, ui_callback))
         except queue.Full:
             self._logger.critical("Task queue is full")
 
@@ -77,7 +83,9 @@ class ClientTaskReactor:
                 func_pair = self._task_queue.get_nowait()
                 if func_pair is None:
                     continue
-                task, completion_callback = func_pair
+                task_id, task, completion_callback = func_pair
+                if self._logger.isEnabledFor(logging.DEBUG):
+                    self._logger.debug(f"Cancelling task #{task_id}")
                 completion_callback(None, StoppedException("Reactor stopped"))
         except queue.Empty:
             pass
@@ -105,12 +113,17 @@ class ClientTaskReactor:
             if func_pair is None:
                 continue
 
-            task, ui_callback = func_pair
+            task_id, task, ui_callback = func_pair
             result:Any = None
             error:Optional[Exception] = None
             try:
+                if self._logger.isEnabledFor(logging.DEBUG):
+                    self._logger.debug(f"Executing task #{task_id}")
                 result = task(self._client)
+                if self._logger.isEnabledFor(logging.DEBUG):
+                    self._logger.debug(f"Task #{task_id} executed")
             except Exception as e:
+                self._logger.debug(f"Task #{task_id} failed")
                 error = e
 
             invoke_in_qt_thread(functools.partial(ui_callback, result, error))

--- a/scrutiny/gui/core/server_manager/client_task_reactor.py
+++ b/scrutiny/gui/core/server_manager/client_task_reactor.py
@@ -1,3 +1,11 @@
+#    client_task_reactor.py
+#        A reactor that can pipeline blocking requests to the server using the synchronous
+#        SDK. Uses a threadpool
+#
+#   - License : MIT - See LICENSE file
+#   - Project : Scrutiny Debugger (github.com/scrutinydebugger/scrutiny-main)
+#
+#    Copyright (c) 2026 Scrutiny Debugger
 
 import queue
 import threading

--- a/scrutiny/gui/core/server_manager/qt_buffered_listener.py
+++ b/scrutiny/gui/core/server_manager/qt_buffered_listener.py
@@ -30,6 +30,7 @@ from scrutiny.gui.app_settings import app_settings
 
 USER_MSG_UPDATE_OVERRUN = "listener_update_dropped"
 
+
 class QtBufferedListener(BaseListener):
     """A listener that can plug into the SDK. This listener receives the updates from the server and buffers them in a queue.
     A signal is emitted when new data is received to tell the UI to come read the queue. The signal is only emitted when the

--- a/scrutiny/gui/core/server_manager/qt_buffered_listener.py
+++ b/scrutiny/gui/core/server_manager/qt_buffered_listener.py
@@ -1,0 +1,120 @@
+from scrutiny import sdk
+import threading
+import time
+import logging
+import queue
+import enum
+from copy import copy
+from dataclasses import dataclass
+
+from PySide6.QtCore import Signal, QObject
+import shiboken6
+
+from scrutiny.sdk.listeners import BaseListener, ValueUpdate
+from scrutiny.gui.core.user_messages_manager import UserMessagesManager
+from scrutiny.gui.core.threads import QT_THREAD_NAME, SERVER_MANAGER_THREAD_NAME
+from scrutiny.gui.tools.invoker import invoke_in_qt_thread_synchronized, invoke_later
+from scrutiny import tools
+from scrutiny.tools.thread_enforcer import thread_func, enforce_thread
+from scrutiny.tools.profiling import VariableRateExponentialAverager
+from scrutiny.tools.typing import *
+from scrutiny.gui.app_settings import app_settings
+
+USER_MSG_UPDATE_OVERRUN = "listener_update_dropped"
+
+class QtBufferedListener(BaseListener):
+    """A listener that can plug into the SDK. This listener receives the updates from the server and buffers them in a queue.
+    A signal is emitted when new data is received to tell the UI to come read the queue. The signal is only emitted when the
+    UI is ready to receive it for natural derating on update speed if the CPU is overloaded"""
+
+    MAX_SIGNALS_PER_SEC = 15
+    """Maximum number of ``data_received`` QT signals this listener is allowed to emit per seconds.
+    Prevent overflowing the event loop"""
+    TARGET_PROCESS_INTERVAL = 0.2
+    """Delay between 2 calls to ``process()``. Override ``BaseListener`` value"""
+
+    class _Signals(QObject):
+        data_received = Signal()
+
+    to_gui_thread_queue: "queue.Queue[List[ValueUpdate]]"
+    """A queue to transfer the value updates to the GUI thread"""
+    signals: _Signals
+    """The signals that this listener can emit"""
+    last_signal_perf_cnt_ns: int
+    """Timestamp of the last signal being sent"""
+    minimal_inter_signal_delay_ns: int = int(1e9 / MAX_SIGNALS_PER_SEC)
+    """Minimal amount of time between two data_received signals"""
+    emit_allowed: bool
+    """Flag preventing overflowing the event loop if the GUI thread is overloaded"""
+    update_dropped_count: int
+    """A counter that keeps track of how many value updates were lost during this session"""
+    _last_drop_message_monotonic_time: Optional[float]
+    """A timestamp used to avoid spamming the logger/messaging system when the queue overflows"""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        BaseListener.__init__(self, *args, **kwargs)
+        self.to_gui_thread_queue = queue.Queue(maxsize=1000)    # Full load test peaks at 50
+        self.signals = self._Signals()
+        self.last_signal_perf_cnt_ns = time.perf_counter_ns()
+        self.emit_allowed = True
+        self.qt_event_rate_measurement = VariableRateExponentialAverager(time_estimation_window=0.1, tau=0.5, near_zero=0.1)
+        self.update_dropped_count = 0
+        self._last_drop_message_monotonic_time = None
+
+    def setup(self) -> None:
+        self.update_dropped_count = 0
+        self.qt_event_rate_measurement.enable()
+        self.emit_allowed = True
+
+    def teardown(self) -> None:
+        self.emit_allowed = False
+        self.qt_event_rate_measurement.disable()
+
+    def ready_for_next_update(self) -> None:
+        self.emit_allowed = True
+
+    def _emit_signal_if_possible(self) -> None:
+        tnow = time.perf_counter_ns()
+        tdiff = tnow - self.last_signal_perf_cnt_ns
+        expired = tdiff >= self.minimal_inter_signal_delay_ns or tdiff < 0  # Unclear if that counter can wrap. being careful here
+        if expired and self.emit_allowed:
+            self.qt_event_rate_measurement.add_data(1)
+            self.last_signal_perf_cnt_ns = tnow
+            self.emit_allowed = False
+            # The signal is created in the main thread, but used in the listener thread
+            # Even very improbable, there is a slight time window where
+            # this signal can be deleted before teardown is called. So suppress the exception for normal operation
+            with tools.LogException(self._logger, RuntimeError, "Failed to emit", str_level=logging.DEBUG, traceback_level=logging.DEBUG):
+                self.signals.data_received.emit()
+
+    def receive(self, updates: List[ValueUpdate]) -> None:
+        try:
+            self.to_gui_thread_queue.put(updates.copy(), block=False)
+        except queue.Full:
+            self.update_dropped_count += 1
+            if self._last_drop_message_monotonic_time is None or time.monotonic() - self._last_drop_message_monotonic_time > 1:
+                msg = f"Value update overrun. Total lost: {self.update_dropped_count} updates"
+                self._logger.error(msg)
+                UserMessagesManager.instance().register_message_thread_safe(USER_MSG_UPDATE_OVERRUN, msg, 3)
+                self._last_drop_message_monotonic_time = time.monotonic()
+
+        self._emit_signal_if_possible()
+
+    def process(self) -> None:
+        # Slow call rate. Called at rate defined by TARGET_PROCESS_INTERVAL
+        if self.gui_qsize > 0:
+            self._emit_signal_if_possible()  # Prune any remaining content if the server stops broadcasting
+        self.qt_event_rate_measurement.update()
+
+    def allow_subscription_changes_while_running(self) -> bool:
+        return True
+
+    @property
+    def gui_qsize(self) -> int:
+        """Return the number of value updates presently stored in the queue linking the listener thread and the QT GUI thread."""
+        return self.to_gui_thread_queue.qsize()
+
+    @property
+    def effective_event_rate(self) -> float:
+        """Returned the measured rate at which the ``data_received`` signal is being emitted"""
+        return self.qt_event_rate_measurement.get_value()

--- a/scrutiny/gui/core/server_manager/qt_buffered_listener.py
+++ b/scrutiny/gui/core/server_manager/qt_buffered_listener.py
@@ -1,3 +1,11 @@
+#    qt_buffered_listener.py
+#        A custom sdk.Listener meant to broadcast value upadtes the the QT GUI.
+#
+#   - License : MIT - See LICENSE file
+#   - Project : Scrutiny Debugger (github.com/scrutinydebugger/scrutiny-main)
+#
+#    Copyright (c) 2026 Scrutiny Debugger
+
 from scrutiny import sdk
 import threading
 import time

--- a/scrutiny/gui/core/server_manager/server_manager.py
+++ b/scrutiny/gui/core/server_manager/server_manager.py
@@ -544,7 +544,7 @@ class ServerManager:
     # region Private QT side methods
 
     def _request_update_rate_change(self, handle: WatchableHandle, update_rate: Optional[float]) -> None:
-        def _ephemerous_thread_change(client: ScrutinyClient) -> Optional[float]:
+        def _threaded_func_change(client: ScrutinyClient) -> Optional[float]:
             return handle.change_update_rate(update_rate)
 
         def _qt_thread_callback(effective_rate: Optional[float], error: Optional[Exception]) -> None:
@@ -554,7 +554,7 @@ class ServerManager:
 
         if self._logger.isEnabledFor(logging.DEBUG):
             self._logger.debug(f"Changing update rate of {handle.server_path} to {update_rate}")
-        self.schedule_client_request(_ephemerous_thread_change, _qt_thread_callback)
+        self.schedule_client_request(_threaded_func_change, _qt_thread_callback)
 
     def _qt_update_registration_from_watchable_handle(self,
                                                       registration_status: WatchableRegistrationStatus,

--- a/scrutiny/gui/core/server_manager/server_manager.py
+++ b/scrutiny/gui/core/server_manager/server_manager.py
@@ -13,13 +13,11 @@ from scrutiny import sdk
 import threading
 import time
 import logging
-import queue
 import enum
 from copy import copy
 from dataclasses import dataclass
 
 from PySide6.QtCore import Signal, QObject
-import shiboken6
 
 from scrutiny.core.logging import DUMPDATA_LOGLEVEL
 from scrutiny.sdk.listeners import BaseListener, ValueUpdate
@@ -27,163 +25,23 @@ from scrutiny.sdk.watchable_handle import WatchableHandle
 from scrutiny.sdk.client import ScrutinyClient, WatchableListDownloadRequest
 from scrutiny.gui.core.watchable_registry import WatchableRegistry, GlobalWatchCallbackData
 from scrutiny.gui.core.user_messages_manager import UserMessagesManager
+from scrutiny.gui.core.server_manager.qt_buffered_listener import QtBufferedListener
+from scrutiny.gui.core.server_manager.client_task_reactor import ClientTaskReactor
 from scrutiny.gui.core.threads import QT_THREAD_NAME, SERVER_MANAGER_THREAD_NAME
 from scrutiny.gui.tools.invoker import invoke_in_qt_thread_synchronized, invoke_later
+
 from scrutiny import tools
 from scrutiny.tools.thread_enforcer import thread_func, enforce_thread
-from scrutiny.tools.profiling import VariableRateExponentialAverager
 from scrutiny.tools.typing import *
 from scrutiny.gui.app_settings import app_settings
 
 USER_MSG_ID_CONNECT_FAILED = "connect_failed"
-USER_MSG_UPDATE_OVERRUN = "listener_update_dropped"
 
 
 @dataclass(slots=True)
 class ServerConfig:
     hostname: str
     port: int
-
-
-class QtBufferedListener(BaseListener):
-    """A listener that can plug into the SDK. This listener receives the updates from the server and buffers them in a queue.
-    A signal is emitted when new data is received to tell the UI to come read the queue. The signal is only emitted when the
-    UI is ready to receive it for natural derating on update speed if the CPU is overloaded"""
-
-    MAX_SIGNALS_PER_SEC = 15
-    """Maximum number of ``data_received`` QT signals this listener is allowed to emit per seconds.
-    Prevent overflowing the event loop"""
-    TARGET_PROCESS_INTERVAL = 0.2
-    """Delay between 2 calls to ``process()``. Override ``BaseListener`` value"""
-
-    class _Signals(QObject):
-        data_received = Signal()
-
-    to_gui_thread_queue: "queue.Queue[List[ValueUpdate]]"
-    """A queue to transfer the value updates to the GUI thread"""
-    signals: _Signals
-    """The signals that this listener can emit"""
-    last_signal_perf_cnt_ns: int
-    """Timestamp of the last signal being sent"""
-    minimal_inter_signal_delay_ns: int = int(1e9 / MAX_SIGNALS_PER_SEC)
-    """Minimal amount of time between two data_received signals"""
-    emit_allowed: bool
-    """Flag preventing overflowing the event loop if the GUI thread is overloaded"""
-    update_dropped_count: int
-    """A counter that keeps track of how many value updates were lost during this session"""
-    _last_drop_message_monotonic_time: Optional[float]
-    """A timestamp used to avoid spamming the logger/messaging system when the queue overflows"""
-
-    def __init__(self, *args: Any, **kwargs: Any):
-        BaseListener.__init__(self, *args, **kwargs)
-        self.to_gui_thread_queue = queue.Queue(maxsize=1000)    # Full load test peaks at 50
-        self.signals = self._Signals()
-        self.last_signal_perf_cnt_ns = time.perf_counter_ns()
-        self.emit_allowed = True
-        self.qt_event_rate_measurement = VariableRateExponentialAverager(time_estimation_window=0.1, tau=0.5, near_zero=0.1)
-        self.update_dropped_count = 0
-        self._last_drop_message_monotonic_time = None
-
-    def setup(self) -> None:
-        self.update_dropped_count = 0
-        self.qt_event_rate_measurement.enable()
-        self.emit_allowed = True
-
-    def teardown(self) -> None:
-        self.emit_allowed = False
-        self.qt_event_rate_measurement.disable()
-
-    def ready_for_next_update(self) -> None:
-        self.emit_allowed = True
-
-    def _emit_signal_if_possible(self) -> None:
-        tnow = time.perf_counter_ns()
-        tdiff = tnow - self.last_signal_perf_cnt_ns
-        expired = tdiff >= self.minimal_inter_signal_delay_ns or tdiff < 0  # Unclear if that counter can wrap. being careful here
-        if expired and self.emit_allowed:
-            self.qt_event_rate_measurement.add_data(1)
-            self.last_signal_perf_cnt_ns = tnow
-            self.emit_allowed = False
-            # The signal is created in the main thread, but used in the listener thread
-            # Even very improbable, there is a slight time window where
-            # this signal can be deleted before teardown is called. So suppress the exception for normal operation
-            with tools.LogException(self._logger, RuntimeError, "Failed to emit", str_level=logging.DEBUG, traceback_level=logging.DEBUG):
-                self.signals.data_received.emit()
-
-    def receive(self, updates: List[ValueUpdate]) -> None:
-        try:
-            self.to_gui_thread_queue.put(updates.copy(), block=False)
-        except queue.Full:
-            self.update_dropped_count += 1
-            if self._last_drop_message_monotonic_time is None or time.monotonic() - self._last_drop_message_monotonic_time > 1:
-                msg = f"Value update overrun. Total lost: {self.update_dropped_count} updates"
-                self._logger.error(msg)
-                UserMessagesManager.instance().register_message_thread_safe(USER_MSG_UPDATE_OVERRUN, msg, 3)
-                self._last_drop_message_monotonic_time = time.monotonic()
-
-        self._emit_signal_if_possible()
-
-    def process(self) -> None:
-        # Slow call rate. Called at rate defined by TARGET_PROCESS_INTERVAL
-        if self.gui_qsize > 0:
-            self._emit_signal_if_possible()  # Prune any remaining content if the server stops broadcasting
-        self.qt_event_rate_measurement.update()
-
-    def allow_subscription_changes_while_running(self) -> bool:
-        return True
-
-    @property
-    def gui_qsize(self) -> int:
-        """Return the number of value updates presently stored in the queue linking the listener thread and the QT GUI thread."""
-        return self.to_gui_thread_queue.qsize()
-
-    @property
-    def effective_event_rate(self) -> float:
-        """Returned the measured rate at which the ``data_received`` signal is being emitted"""
-        return self.qt_event_rate_measurement.get_value()
-
-
-class ClientRequestStore:
-    @dataclass(slots=True)
-    class ClientRequestEntry:
-        ui_callback: Callable[[Any, Optional[Exception]], None]
-        threaded_func_return_value: Any
-        error: Optional[Exception]
-
-    _next_id: int
-    _storage: Dict[int, ClientRequestEntry]
-    _lock: threading.Lock
-
-    def __init__(self) -> None:
-        self._next_id = 0
-        self._storage = dict()
-        self._lock = threading.Lock()
-
-    def clear(self) -> None:
-        with self._lock:
-            self._storage.clear()
-            self._next_id = 0
-
-    def register(self, entry: ClientRequestEntry) -> int:
-        """Register a request in the storage and return a unique, monotonic ID"""
-        with self._lock:
-            while self._next_id in self._storage:
-                self._next_id += 1
-            assigned_id = self._next_id
-            self._storage[assigned_id] = entry
-            self._next_id += 1
-
-        return assigned_id
-
-    def get(self, storage_id: int) -> Optional[ClientRequestEntry]:
-        try:
-            with self._lock:
-                entry = self._storage[storage_id]
-                del self._storage[storage_id]
-            return entry
-        except KeyError:
-            return None
-
 
 class ServerManager:
     """Runs a thread for the synchronous SDK and emit QT events when something interesting happens"""
@@ -252,7 +110,6 @@ class ServerManager:
 
     class _InternalSignals(QObject):
         thread_exit_signal = Signal()
-        client_request_completed = Signal(int)
 
     class _Signals(QObject):    # QObject required for signals to work
         """Signals offered to the outside world"""
@@ -300,8 +157,8 @@ class ServerManager:
 
     _stop_pending: bool
     """Indicate if a stop is in progress. ``True`` between calls to stop() and emission of ``stopped`` signal"""
-    _client_request_store: ClientRequestStore
-    """A storage for SDK client request that are scheduled to run in a different thread. See ``schedule_client_request``"""
+    _client_task_reactor:ClientTaskReactor
+    """A reactor that can pipeline blocking requests to the server"""
     _listener: QtBufferedListener
     """A custom listener that passes the data from the SDK client thread to the QT GUI thread"""
     _status_update_received: int
@@ -349,9 +206,8 @@ class ServerManager:
         }
 
         self._internal_signals.thread_exit_signal.connect(self._qt_thread_join_thread_and_emit_stopped)
-        self._internal_signals.client_request_completed.connect(self._qt_client_request_completed)
         self._stop_pending = False
-        self._client_request_store = ClientRequestStore()
+        self._client_task_reactor = ClientTaskReactor(self._client, nb_thread=16, queue_max_size=100)
         self._registry.register_global_watch_callback(self._qt_registry_watch_callback, self._qt_registry_unwatch_callback)
 
         self._listener = QtBufferedListener()
@@ -901,21 +757,6 @@ class ServerManager:
         self._registry.broadcast_value_updates_to_watchers(aggregated_updates)
         self._listener.ready_for_next_update()
 
-    def _qt_client_request_completed(self, store_id: int) -> None:
-        # This runs in the UI thread
-        entry = self._client_request_store.get(store_id)
-        if entry is None:
-            self._logger.debug("Client request completed, but entry not part of the store.")
-            return
-
-        if self._exit_in_progress:
-            # Prevents weird behavior on app exit, like accessing deleted resources
-            # The main window is expected to call exit() before exiting.
-            self._logger.debug("Client request completed, but the server manager has been stopped. Ignoring.")
-            return
-
-        entry.ui_callback(entry.threaded_func_return_value, entry.error)
-
     @enforce_thread(QT_THREAD_NAME)
     def _qt_thread_join_thread_and_emit_stopped(self) -> None:
         """Called when the stop process is completed. Triggered by the internal thread, executed in the QT thread"""
@@ -1062,37 +903,7 @@ class ServerManager:
                                 ) -> None:
         """Runs a client request in a separate thread and calls a callback in the UI thread when done."""
         # Thread safe. Can be called from any thread
-
-        def threaded_func() -> None:
-            # This runs in a separate thread
-            error: Optional[Exception] = None
-            return_val: Any = None
-            try:
-                return_val = user_func(self._client)
-            except Exception as e:
-                error = e
-
-            if self._exit_in_progress:
-                return
-
-            # A race condition is possible here when exiting the application
-            # Resources can be deleted between here and the end.
-
-            entry = ClientRequestStore.ClientRequestEntry(
-                ui_callback=ui_thread_callback,
-                threaded_func_return_value=return_val,
-                error=error
-            )
-            assigned_id = self._client_request_store.register(entry)
-            try:
-                self._internal_signals.client_request_completed.emit(assigned_id)
-            except Exception as e:
-                # Expected to fail if QT has deleted internal resources
-                if not self._exit_in_progress:
-                    self._logger.error(f"Failed to emit client_request_completed signal. {e}")
-
-        t = threading.Thread(target=threaded_func, daemon=True)
-        t.start()
+        self._client_task_reactor.put_task(user_func, ui_thread_callback)
 
     def get_server_state(self) -> sdk.ServerState:
         # Called from QT thread + Server thread. atomic
@@ -1181,10 +992,10 @@ class ServerManager:
         self._logger.debug("Starting server manager")
         self._set_device_info(None)
         self._set_loaded_sfd(None)
-        self._client_request_store.clear()
         self.signals.starting.emit()
         self._allow_auto_reconnect = True
         self._thread_stop_event.clear()
+        self._client_task_reactor.start()
         self._thread = threading.Thread(target=self._thread_func, args=[config], daemon=True)
         self._listener.reset_stats()
         self._thread.start()
@@ -1215,6 +1026,7 @@ class ServerManager:
         # Will cause the thread to exit and emit thread_exit_signal that triggers _qt_thread_join_thread_and_emit_stopped in the UI thread
         self._thread_stop_event.set()
         self._client.close_socket()   # Will cancel any pending request in the other thread
+        self._client_task_reactor.stop()
         self._logger.debug("Stop initiated")
 
     def is_running(self) -> bool:

--- a/scrutiny/gui/core/server_manager/server_manager.py
+++ b/scrutiny/gui/core/server_manager/server_manager.py
@@ -43,6 +43,7 @@ class ServerConfig:
     hostname: str
     port: int
 
+
 class ServerManager:
     """Runs a thread for the synchronous SDK and emit QT events when something interesting happens"""
 
@@ -157,7 +158,7 @@ class ServerManager:
 
     _stop_pending: bool
     """Indicate if a stop is in progress. ``True`` between calls to stop() and emission of ``stopped`` signal"""
-    _client_task_reactor:ClientTaskReactor
+    _client_task_reactor: ClientTaskReactor
     """A reactor that can pipeline blocking requests to the server"""
     _listener: QtBufferedListener
     """A custom listener that passes the data from the SDK client thread to the QT GUI thread"""

--- a/scrutiny/gui/dashboard/dashboard.py
+++ b/scrutiny/gui/dashboard/dashboard.py
@@ -38,7 +38,7 @@ from scrutiny.gui.dashboard import dashboard_file_format
 from scrutiny.gui.app_settings import app_settings
 from scrutiny.gui.core.persistent_data import gui_persistent_data
 from scrutiny.gui.core.watchable_registry import WatchableRegistry
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 
 from scrutiny.gui.widgets.scrutiny_qmenu import ScrutinyQMenu
 

--- a/scrutiny/gui/dialogs/server_config_dialog.py
+++ b/scrutiny/gui/dialogs/server_config_dialog.py
@@ -23,7 +23,7 @@ from scrutiny.gui.themes import scrutiny_get_theme
 
 from scrutiny.gui import DEFAULT_SERVER_PORT
 from scrutiny.gui.tools.validators import IpPortValidator, NotEmptyValidator
-from scrutiny.gui.core.server_manager.server_manager  import ServerConfig
+from scrutiny.gui.core.server_manager.server_manager import ServerConfig
 from scrutiny.gui.core.local_server_runner import LocalServerRunner
 from scrutiny.gui.core.persistent_data import gui_persistent_data, AppPersistentData
 from scrutiny.gui import assets

--- a/scrutiny/gui/dialogs/server_config_dialog.py
+++ b/scrutiny/gui/dialogs/server_config_dialog.py
@@ -23,7 +23,7 @@ from scrutiny.gui.themes import scrutiny_get_theme
 
 from scrutiny.gui import DEFAULT_SERVER_PORT
 from scrutiny.gui.tools.validators import IpPortValidator, NotEmptyValidator
-from scrutiny.gui.core.server_manager import ServerConfig
+from scrutiny.gui.core.server_manager.server_manager  import ServerConfig
 from scrutiny.gui.core.local_server_runner import LocalServerRunner
 from scrutiny.gui.core.persistent_data import gui_persistent_data, AppPersistentData
 from scrutiny.gui import assets

--- a/scrutiny/gui/dialogs/server_sfd_manager_dialog.py
+++ b/scrutiny/gui/dialogs/server_sfd_manager_dialog.py
@@ -364,7 +364,7 @@ class ServerSFDManagerDialog(QDialog):
         # Let's send a request to the server for uninstalling the selected SFD
         self._feedback_label.clear()
 
-        def ephemerous_thread_request_uninstall(client: ScrutinyClient) -> None:
+        def threded_func_request_uninstall(client: ScrutinyClient) -> None:
             client.uninstall_sfds(firmware_ids)  # Blocking request
 
         def ui_thread_uninstall_complete(response: None, error: Optional[Exception]) -> None:
@@ -379,7 +379,7 @@ class ServerSFDManagerDialog(QDialog):
             self._feedback_label.set_success(f"Uninstalled {nb_sfd} Scrutiny Firmware Description (SFD) files.")
 
         self._server_manager.schedule_client_request(
-            user_func=ephemerous_thread_request_uninstall,
+            user_func=threded_func_request_uninstall,
             ui_thread_callback=ui_thread_uninstall_complete
         )
 
@@ -391,7 +391,7 @@ class ServerSFDManagerDialog(QDialog):
         if self.is_transfer_active():
             return
 
-        def ephemerous_thread_request_download(client: ScrutinyClient) -> bytes:
+        def threded_func_request_download(client: ScrutinyClient) -> bytes:
             req = client.download_sfd(sfd_info.firmware_id)
             self._internal_signals.sfd_transfer_started.emit(req)
             req.wait_for_completion()   # Blocking call
@@ -419,7 +419,7 @@ class ServerSFDManagerDialog(QDialog):
                     tools.log_exception(self._logger, e, f"Failed to save SFD to {save_path}")
 
         self._server_manager.schedule_client_request(
-            user_func=ephemerous_thread_request_download,
+            user_func=threded_func_request_download,
             ui_thread_callback=ui_thread_download_complete
         )
 
@@ -456,7 +456,7 @@ class ServerSFDManagerDialog(QDialog):
         if filepath is None:
             return
 
-        def ephemerous_thread_upload_init(client: ScrutinyClient) -> SFDUploadRequest:
+        def threded_func_upload_init(client: ScrutinyClient) -> SFDUploadRequest:
             return client.init_sfd_upload(filepath)
 
         def ui_thread_upload_init_completed(req: Optional[SFDUploadRequest], error: Optional[Exception]) -> None:
@@ -480,7 +480,7 @@ class ServerSFDManagerDialog(QDialog):
 
             self._internal_signals.sfd_transfer_started.emit(req)
 
-            def ephemerous_thread_upload(client: ScrutinyClient) -> SFDUploadRequest:
+            def threded_func_upload(client: ScrutinyClient) -> SFDUploadRequest:
                 req.start()
                 req.wait_for_completion()
                 return req
@@ -502,12 +502,12 @@ class ServerSFDManagerDialog(QDialog):
                 prompt.success_msgbox("Installed", f"Installed SFD {data.firmware_id}")
 
             self._server_manager.schedule_client_request(
-                user_func=ephemerous_thread_upload,
+                user_func=threded_func_upload,
                 ui_thread_callback=ui_thread_upload_complete
             )
 
         self._server_manager.schedule_client_request(
-            user_func=ephemerous_thread_upload_init,
+            user_func=threded_func_upload_init,
             ui_thread_callback=ui_thread_upload_init_completed
         )
 
@@ -520,7 +520,7 @@ class ServerSFDManagerDialog(QDialog):
         """Downloads the installed SFD from the server and populates the table view"""
         self.clear_sfd_list()
 
-        def ephemerous_thread_request_download(client: ScrutinyClient) -> Dict[str, sdk.SFDInfo]:
+        def threded_func_request_download(client: ScrutinyClient) -> Dict[str, sdk.SFDInfo]:
             return client.get_installed_sfds()  # Blocking call
 
         def ui_thread_download_callback(sfds: Optional[Dict[str, sdk.SFDInfo]], error: Optional[Exception]) -> None:
@@ -538,7 +538,7 @@ class ServerSFDManagerDialog(QDialog):
             self._sfd_table.sortByColumn(SFDTableModel.Cols.CREATION_DATE, Qt.SortOrder.DescendingOrder)
 
         self._server_manager.schedule_client_request(
-            user_func=ephemerous_thread_request_download,
+            user_func=threded_func_request_download,
             ui_thread_callback=ui_thread_download_callback
         )
 

--- a/scrutiny/gui/dialogs/server_sfd_manager_dialog.py
+++ b/scrutiny/gui/dialogs/server_sfd_manager_dialog.py
@@ -18,7 +18,7 @@ from PySide6.QtGui import QCloseEvent, QKeyEvent, QShowEvent, QStandardItemModel
 
 from scrutiny import sdk
 from scrutiny.sdk.client import ScrutinyClient, SFDUploadRequest, SFDDownloadRequest
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager  import ServerManager
 from scrutiny.gui.core.persistent_data import gui_persistent_data
 from scrutiny.gui.themes import scrutiny_get_theme
 from scrutiny.gui.widgets.feedback_label import FeedbackLabel

--- a/scrutiny/gui/dialogs/server_sfd_manager_dialog.py
+++ b/scrutiny/gui/dialogs/server_sfd_manager_dialog.py
@@ -18,7 +18,7 @@ from PySide6.QtGui import QCloseEvent, QKeyEvent, QShowEvent, QStandardItemModel
 
 from scrutiny import sdk
 from scrutiny.sdk.client import ScrutinyClient, SFDUploadRequest, SFDDownloadRequest
-from scrutiny.gui.core.server_manager.server_manager  import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 from scrutiny.gui.core.persistent_data import gui_persistent_data
 from scrutiny.gui.themes import scrutiny_get_theme
 from scrutiny.gui.widgets.feedback_label import FeedbackLabel

--- a/scrutiny/gui/dialogs/value_export_dialog.py
+++ b/scrutiny/gui/dialogs/value_export_dialog.py
@@ -26,7 +26,7 @@ from scrutiny.gui.core.serializable_value_set import SerializableValueSet
 from scrutiny.gui.core.watchable_registry import WatchableRegistry, WatcherNotFoundError, RegistryValueUpdate, WatchableRegistryError, ParsedFullyQualifiedName
 from scrutiny.gui.widgets.watchable_tree import get_watchable_icon
 from scrutiny.gui.widgets.scrutiny_qmenu import ScrutinyQMenu
-from scrutiny.gui.core.server_manager.server_manager  import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 from scrutiny.gui.tools.invoker import invoke_later
 from scrutiny.gui.widgets.feedback_label import FeedbackLabel
 from scrutiny.gui.themes import scrutiny_get_theme
@@ -344,6 +344,7 @@ class ExportLogic:
 
 
 # region Private
+
 
     def _get_state_by_fqn(self, fqn: str) -> ValueDownloadState:
         """Fetch the state object based on its fully Qualified Name"""

--- a/scrutiny/gui/dialogs/value_export_dialog.py
+++ b/scrutiny/gui/dialogs/value_export_dialog.py
@@ -26,7 +26,7 @@ from scrutiny.gui.core.serializable_value_set import SerializableValueSet
 from scrutiny.gui.core.watchable_registry import WatchableRegistry, WatcherNotFoundError, RegistryValueUpdate, WatchableRegistryError, ParsedFullyQualifiedName
 from scrutiny.gui.widgets.watchable_tree import get_watchable_icon
 from scrutiny.gui.widgets.scrutiny_qmenu import ScrutinyQMenu
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager  import ServerManager
 from scrutiny.gui.tools.invoker import invoke_later
 from scrutiny.gui.widgets.feedback_label import FeedbackLabel
 from scrutiny.gui.themes import scrutiny_get_theme

--- a/scrutiny/gui/dialogs/value_import_dialog.py
+++ b/scrutiny/gui/dialogs/value_import_dialog.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 
 from scrutiny.gui.core.serializable_value_set import SerializableValueSet
 from scrutiny.gui.core.watchable_registry import WatchableRegistry, ParsedFullyQualifiedName, WatchableRegistryError
-from scrutiny.gui.core.server_manager.server_manager  import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 from scrutiny.gui.widgets.watchable_tree import get_watchable_icon
 from scrutiny.gui.widgets.scrutiny_qmenu import ScrutinyQMenu
 from scrutiny.gui.tools.invoker import invoke_later

--- a/scrutiny/gui/dialogs/value_import_dialog.py
+++ b/scrutiny/gui/dialogs/value_import_dialog.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 
 from scrutiny.gui.core.serializable_value_set import SerializableValueSet
 from scrutiny.gui.core.watchable_registry import WatchableRegistry, ParsedFullyQualifiedName, WatchableRegistryError
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager  import ServerManager
 from scrutiny.gui.widgets.watchable_tree import get_watchable_icon
 from scrutiny.gui.widgets.scrutiny_qmenu import ScrutinyQMenu
 from scrutiny.gui.tools.invoker import invoke_later

--- a/scrutiny/gui/dialogs/value_import_dialog.py
+++ b/scrutiny/gui/dialogs/value_import_dialog.py
@@ -284,7 +284,7 @@ class ValueImportDialog(QDialog):
 
         try:
             self._server_manager.schedule_client_request(
-                user_func=functools.partial(self._ephemerous_thread_write_func, path_item.get_path(), value_to_write),
+                user_func=functools.partial(self._threaded_func_write_func, path_item.get_path(), value_to_write),
                 ui_thread_callback=functools.partial(self._qt_thread_write_callback, row)
             )
         except Exception as e:
@@ -293,7 +293,7 @@ class ValueImportDialog(QDialog):
             invoke_later(start_write_next_row)
             return
 
-    def _ephemerous_thread_write_func(self, path: str, value: Union[int, bool, float, str], client: ScrutinyClient) -> None:
+    def _threaded_func_write_func(self, path: str, value: Union[int, bool, float, str], client: ScrutinyClient) -> None:
         """Executed in a background thread. Blocks until completion"""
         self._logger.debug(f"Write value ({value}) of {path}")
         client.write_watchable(path, value)

--- a/scrutiny/gui/main_window.py
+++ b/scrutiny/gui/main_window.py
@@ -43,7 +43,7 @@ from scrutiny.gui.components.locals.hmi.hmi_component import HMIComponent
 from scrutiny.gui.components.globals.metrics.metrics_component import MetricsComponent
 
 from scrutiny.gui.core.user_messages_manager import UserMessagesManager
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 from scrutiny.gui.core.watchable_registry import WatchableRegistry
 
 from scrutiny import tools

--- a/scrutiny/gui/widgets/app_stats_display.py
+++ b/scrutiny/gui/widgets/app_stats_display.py
@@ -11,7 +11,7 @@ __all__ = ['ApplicationStatsDisplay']
 from PySide6.QtWidgets import QWidget, QFormLayout, QLabel, QGroupBox, QVBoxLayout
 from PySide6.QtCore import Qt
 from scrutiny import sdk
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager  import ServerManager
 from scrutiny.tools import format_eng_unit, format_sec_to_dhms
 from scrutiny.tools.typing import *
 

--- a/scrutiny/gui/widgets/app_stats_display.py
+++ b/scrutiny/gui/widgets/app_stats_display.py
@@ -11,7 +11,7 @@ __all__ = ['ApplicationStatsDisplay']
 from PySide6.QtWidgets import QWidget, QFormLayout, QLabel, QGroupBox, QVBoxLayout
 from PySide6.QtCore import Qt
 from scrutiny import sdk
-from scrutiny.gui.core.server_manager.server_manager  import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 from scrutiny.tools import format_eng_unit, format_sec_to_dhms
 from scrutiny.tools.typing import *
 

--- a/scrutiny/gui/widgets/status_bar.py
+++ b/scrutiny/gui/widgets/status_bar.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import QStatusBar, QWidget, QLabel, QHBoxLayout, QSizePol
 from PySide6.QtCore import Qt, QPoint
 from PySide6.QtGui import QPixmap, QAction
 
-from scrutiny.gui.core.server_manager.server_manager  import ServerManager
+from scrutiny.gui.core.server_manager.server_manager import ServerManager
 from scrutiny.gui.core.local_server_runner import LocalServerRunner
 from scrutiny.gui.core.user_messages_manager import UserMessagesManager, UserMessage
 from scrutiny.gui.dialogs.server_config_dialog import ServerConfigDialog

--- a/scrutiny/gui/widgets/status_bar.py
+++ b/scrutiny/gui/widgets/status_bar.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import QStatusBar, QWidget, QLabel, QHBoxLayout, QSizePol
 from PySide6.QtCore import Qt, QPoint
 from PySide6.QtGui import QPixmap, QAction
 
-from scrutiny.gui.core.server_manager import ServerManager
+from scrutiny.gui.core.server_manager.server_manager  import ServerManager
 from scrutiny.gui.core.local_server_runner import LocalServerRunner
 from scrutiny.gui.core.user_messages_manager import UserMessagesManager, UserMessage
 from scrutiny.gui.dialogs.server_config_dialog import ServerConfigDialog

--- a/test/gui/base_gui_test.py
+++ b/test/gui/base_gui_test.py
@@ -18,6 +18,8 @@ from scrutiny.gui.core.qt import make_qt_app
 from scrutiny.gui.themes import scrutiny_set_theme
 from scrutiny.gui.themes.default_theme import DefaultTheme
 from scrutiny.gui.core.user_messages_manager import UserMessagesManager
+from scrutiny.gui.app_settings import configure_unit_test_app_settings
+from scrutiny.gui.gui import ScrutinyQtGUI, SupportedTheme
 from scrutiny.gui import assets
 
 from scrutiny.tools.typing import *
@@ -65,6 +67,17 @@ class ScrutinyBaseGuiTest(ScrutinyUnitTest):
             self.app = make_qt_app([])
             UserMessagesManager.init()
             assets.initialize_fonts()
+
+            settings = ScrutinyQtGUI.Settings(
+                debug_layout=False,
+                auto_connect=False,
+                opengl_enabled=False,
+                local_server_port=8765,
+                start_local_server=False,
+                theme=SupportedTheme.Default
+            )
+
+            configure_unit_test_app_settings(settings)
 
         scrutiny_set_theme(self.app, DefaultTheme())
 

--- a/test/gui/fake_server_manager.py
+++ b/test/gui/fake_server_manager.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass
 from PySide6.QtCore import Signal, QObject, QTimer
 from scrutiny.gui.core.watchable_registry import WatchableRegistry
-from scrutiny.gui.core.server_manager import ServerConfig
+from scrutiny.gui.core.server_manager.server_manager  import ServerConfig
 from test.gui.fake_sdk_client import StubbedWatchableHandle, FakeSDKClient
 from scrutiny import sdk
 from uuid import uuid4

--- a/test/gui/fake_server_manager.py
+++ b/test/gui/fake_server_manager.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass
 from PySide6.QtCore import Signal, QObject, QTimer
 from scrutiny.gui.core.watchable_registry import WatchableRegistry
-from scrutiny.gui.core.server_manager.server_manager  import ServerConfig
+from scrutiny.gui.core.server_manager.server_manager import ServerConfig
 from test.gui.fake_sdk_client import StubbedWatchableHandle, FakeSDKClient
 from scrutiny import sdk
 from uuid import uuid4

--- a/test/gui/test_dashboard.py
+++ b/test/gui/test_dashboard.py
@@ -99,15 +99,6 @@ class MainWindowStub(QWidget):
 class TestDashboard(ScrutinyBaseGuiTest):
     def setUp(self):
         super().setUp()
-        settings = ScrutinyQtGUI.Settings(
-            debug_layout=False,
-            auto_connect=False,
-            opengl_enabled=False,
-            local_server_port=8765,
-            start_local_server=False,
-            theme=SupportedTheme.Default
-        )
-        configure_unit_test_app_settings(settings)
         self.main_window = MainWindowStub()
 
     def test_setup_teardown(self):

--- a/test/gui/test_hmi_component.py
+++ b/test/gui/test_hmi_component.py
@@ -62,16 +62,6 @@ class HMIComponentBaseTest(ScrutinyBaseGuiTest):
         self.paint_device = QImage(640, 480, QImage.Format.Format_RGB32)
         self.paint_device.fill(Qt.GlobalColor.white)
 
-        settings = ScrutinyQtGUI.Settings(
-            debug_layout=False,
-            auto_connect=False,
-            opengl_enabled=False,
-            local_server_port=8765,
-            start_local_server=False,
-            theme=SupportedTheme.Default
-        )
-        configure_unit_test_app_settings(settings)
-
         self.main_window = MainWindowStub()
         self.app_interface = DummyAppInterface()
         self.app_interface.server_manager = self.main_window.get_server_manager()

--- a/test/gui/test_server_manager.py
+++ b/test/gui/test_server_manager.py
@@ -7,7 +7,8 @@
 #    Copyright (c) 2024 Scrutiny Debugger
 
 from scrutiny import sdk
-from scrutiny.gui.core.server_manager import ServerManager, ServerConfig, QtBufferedListener
+from scrutiny.gui.core.server_manager.server_manager import ServerManager, ServerConfig
+from scrutiny.gui.core.server_manager.qt_buffered_listener import QtBufferedListener
 from scrutiny.gui.core.watchable_registry import WatchableRegistry
 from test.gui.fake_sdk_client import FakeSDKClient, StubbedWatchableHandle
 from test.gui.base_gui_test import ScrutinyBaseGuiTest, EventType
@@ -489,6 +490,7 @@ class TestServerManager(ScrutinyBaseGuiTest):
             time.sleep(0.5)
             return "hello"
 
+        self.server_manager.start(SERVER_MANAGER_CONFIG)
         self.server_manager.schedule_client_request(func_success, ui_callback)
         self.wait_true_with_events(lambda: data.callback_called, 3)
 

--- a/test/gui/test_watch_component.py
+++ b/test/gui/test_watch_component.py
@@ -40,16 +40,6 @@ class TestWatchComponent(ScrutinyBaseGuiTest):
     def setUp(self):
         super().setUp()
 
-        settings = ScrutinyQtGUI.Settings(
-            debug_layout=False,
-            auto_connect=False,
-            opengl_enabled=False,
-            local_server_port=8765,
-            start_local_server=False,
-            theme=SupportedTheme.Default
-        )
-        configure_unit_test_app_settings(settings)
-
         self.main_window = MainWindowStub()
         app_interface = DummyAppInterface()
         app_interface.server_manager = self.main_window.get_server_manager()


### PR DESCRIPTION
There was no mechanism to prevent an unreasonable amount of pipelined requests.
Use a thread pool of 16 workers that executes tasks from a queue instead of 1 ephemerous thread per request