### PR TITLE
Fixed race condition in CrossThreadInvoker

### DIFF
--- a/scrutiny/gui/tools/invoker.py
+++ b/scrutiny/gui/tools/invoker.py
@@ -12,6 +12,7 @@ __all__ = [
     'invoke_in_qt_thread_synchronized'
 ]
 
+import queue
 from scrutiny import tools
 from scrutiny.gui.core.threads import QT_THREAD_NAME
 from scrutiny.tools.thread_enforcer import enforce_thread
@@ -22,8 +23,10 @@ from scrutiny.tools.typing import *
 
 
 class CrossThreadInvoker(QObject):
-    called_signal = Signal()
+
+    _task_queue: "queue.Queue[Callable[[], None]]"
     _instance: Optional["CrossThreadInvoker"] = None
+    _not_empty_signal = Signal()
 
     @classmethod
     @enforce_thread(QT_THREAD_NAME)
@@ -50,10 +53,22 @@ class CrossThreadInvoker(QObject):
         main_thread = app.thread()
         self.moveToThread(main_thread)
         self.setParent(app)
+        self._task_queue = queue.Queue()
+        self._not_empty_signal.connect(self._qt_process_func, Qt.ConnectionType.QueuedConnection)
 
     def exec(self, method: Callable[[], None]) -> None:
-        self.called_signal.connect(method, Qt.ConnectionType.SingleShotConnection)
-        self.called_signal.emit()
+        """To be invoked in a non QT thread"""
+        self._task_queue.put(method)
+        self._not_empty_signal.emit()
+
+    @enforce_thread(QT_THREAD_NAME)
+    def _qt_process_func(self) -> None:
+        while True:
+            try:
+                task = self._task_queue.get_nowait()
+                task()
+            except queue.Empty:
+                break
 
 
 class QueuedInvoker(QObject):

--- a/test/gui/test_invoker.py
+++ b/test/gui/test_invoker.py
@@ -7,9 +7,11 @@
 #    Copyright (c) 2024 Scrutiny Debugger
 
 import threading
+import functools
 from test.gui.base_gui_test import ScrutinyBaseGuiTest
 from scrutiny.gui.tools.invoker import invoke_in_qt_thread_synchronized, CrossThreadInvoker
 from scrutiny import tools
+import time
 
 
 class TestInvoker(ScrutinyBaseGuiTest):
@@ -31,3 +33,40 @@ class TestInvoker(ScrutinyBaseGuiTest):
         self.wait_true_with_events(finished.is_set, 1)
         self.assertTrue(finished.is_set())
         self.assertEqual(thread_id.val, threading.get_ident())
+
+    def test_stress_test_invoker(self):
+        CrossThreadInvoker.init()
+        nbthread = 64
+        iteration = 50
+        threads_ids = [[] for x in range(nbthread)]
+
+        def func(index):
+            threads_ids[index].append(threading.get_ident())
+
+        lock = threading.Lock()
+        finished_count = tools.MutableInt(0)
+        start_event = threading.Event()
+
+        def thread_func(index):
+            start_event.wait()
+            for i in range(iteration):
+                invoke_in_qt_thread_synchronized(functools.partial(func, index))
+                with lock:
+                    finished_count.val += 1
+                time.sleep(0)
+
+        threads = []
+        for i in range(nbthread):
+            thread = threading.Thread(target=thread_func, args=[i], daemon=True)
+            thread.start()
+            threads.append(thread)
+
+        wanted_count = iteration * nbthread
+        start_event.set()
+        self.wait_true_with_events(lambda: finished_count.val == wanted_count, 10)
+        self.assertEqual(finished_count.val, wanted_count)
+        self.assertEqual(len(threads_ids), nbthread)
+        for bucket in threads_ids:
+            self.assertEqual(len(bucket), iteration)
+            for thread_id in bucket:
+                self.assertEqual(thread_id, threading.get_ident())


### PR DESCRIPTION
Had an implicit depth of 1, could drop calls